### PR TITLE
Add [skip ci] to auto-update commit message for versioning in remote repo

### DIFF
--- a/.github/workflows/release_automation.yml
+++ b/.github/workflows/release_automation.yml
@@ -255,7 +255,7 @@ jobs:
           # Check if there are changes
           if [[ -n $(git status -s) ]]; then
             git add manifest.json
-            git commit -m "Auto-Update MediaBar Enhanced to v${{ env.VERSION }}"
+            git commit -m "Auto-Update MediaBar Enhanced to v${{ env.VERSION }} [skip ci]"
             git push
           else
             echo "No changes to seasonal manifest."


### PR DESCRIPTION
- Add [skip ci] to auto-update commit message for versioning in remote repo