### PR TITLE
Fix issues with persistent slides-container visibility

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.css
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.css
@@ -170,6 +170,12 @@
   height: 90%;
   overflow: hidden;
   margin: 0 auto;
+  pointer-events: auto;
+}
+
+#slides-container[style*="display: none"],
+#slides-container[style*="visibility: hidden"] {
+  pointer-events: none !important;
 }
 
 .arrow {

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -1266,7 +1266,7 @@ class SlideTimer {
  * Observer for handling slideshow visibility based on current page
  */
 const VisibilityObserver = {
-  updateVisibility() {
+  updateVisibility: function() {
     const activeTab = document.querySelector(".emby-tab-button-active");
     const container = document.getElementById("slides-container");
 
@@ -1275,9 +1275,12 @@ const VisibilityObserver = {
     const isVisible =
       (window.location.hash === "#/home.html" ||
         window.location.hash === "#/home") &&
+      activeTab &&
       activeTab.getAttribute("data-index") === "0";
 
     container.style.display = isVisible ? "block" : "none";
+    container.style.visibility = isVisible ? "visible" : "hidden";
+    container.style.pointerEvents = isVisible ? "auto" : "none";
 
     if (isVisible) {
       if (STATE.slideshow.slideInterval && !STATE.slideshow.isPaused) {
@@ -1296,11 +1299,11 @@ const VisibilityObserver = {
    * Initializes visibility observer
    */
   init() {
-    const observer = new MutationObserver(this.updateVisibility);
+    const observer = new MutationObserver(() => this.updateVisibility());
     observer.observe(document.body, { childList: true, subtree: true });
 
-    document.body.addEventListener("click", this.updateVisibility);
-    window.addEventListener("hashchange", this.updateVisibility);
+    document.body.addEventListener("click", () => this.updateVisibility());
+    window.addEventListener("hashchange", () => this.updateVisibility());
 
     this.updateVisibility();
   },


### PR DESCRIPTION
Hello! This should fix the issue where sometimes if you navigate to a library view or the admin dash, it keeps the slides-container element up on the screen, preventing the user from accessing any of the items below.