### PR TITLE
Scope local video pause to Media Bar slides

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -2571,8 +2571,10 @@ const SlideshowManager = {
         }
       }, CONFIG.fadeTransitionDuration);
 
-      // 2. Pause all other HTML5 videos e.g. local trailers
-      document.querySelectorAll('video').forEach(video => {
+      // 2. Pause other Media Bar HTML5 videos e.g. local trailers.
+      // Do not pause every <video> in Jellyfin Web: other plugins such as
+      // HoverTrailer also render local trailers as HTML5 videos.
+      container.querySelectorAll('video').forEach(video => {
         if (!video.closest(`.slide[data-item-id="${currentItemId}"]`)) {
           video.pause();
         }


### PR DESCRIPTION
## Summary
- Scope Media Bar Enhanced's HTML5 video pause logic to its own slideshow container.
- Prevent slide transitions from pausing local trailer videos rendered by other Jellyfin Web plugins, such as HoverTrailer.

## Test Plan
- Built with `dotnet publish Jellyfin.Plugin.MediaBarEnhanced/Jellyfin.Plugin.MediaBarEnhanced.csproj -c Release -v quiet`.
- Deployed the patched DLL on Jellyfin 10.11.8 and verified local HoverTrailer previews continue playing when Media Bar advances to the next slide.
