### PR TITLE
Render title fallback when item has no Logo image

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.css
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.css
@@ -469,6 +469,19 @@
   font-size: 4rem;
 }
 
+.logo-title-fallback {
+  color: #fff;
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1.1;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  max-width: 100%;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 .plot-container {
   position: absolute;
   top: calc(50% + 8vh);

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -2166,17 +2166,28 @@ const SlideCreator = {
         backdropContainer.appendChild(videoBackdrop);
     }
 
-    const logo = SlideUtils.createElement("img", {
-      className: "logo high-quality",
-      src: this.buildImageUrl(item, "Logo", undefined, serverAddress, 40),
-      alt: item.Name,
-      loading: "eager",
-    });
-
+    const hasLogo = !!(item.ImageTags && item.ImageTags.Logo);
     const logoContainer = SlideUtils.createElement("div", {
       className: "logo-container",
     });
-    logoContainer.appendChild(logo);
+    const titleFallback = SlideUtils.createElement("div", {
+      className: "logo-title-fallback",
+    }, item.Name || "");
+    if (hasLogo) {
+      const logo = SlideUtils.createElement("img", {
+        className: "logo high-quality",
+        src: this.buildImageUrl(item, "Logo", undefined, serverAddress, 40),
+        alt: item.Name,
+        loading: "eager",
+      });
+      logo.onerror = () => {
+        logo.remove();
+        logoContainer.appendChild(titleFallback);
+      };
+      logoContainer.appendChild(logo);
+    } else {
+      logoContainer.appendChild(titleFallback);
+    }
 
     const featuredContent = SlideUtils.createElement(
       "div",


### PR DESCRIPTION
## Summary
- Skip the logo `<img>` entirely when `item.ImageTags.Logo` is absent, avoiding the browser's broken-image placeholder.
- Render the item `Name` as styled text inside `.logo-container` so the slide still has a readable title.
- Fall back to the same text node if a logo request that should have succeeded fails to load.

## Test plan
- [ ] Load a library where some items have no Logo image and confirm the item name renders as styled text instead of a broken image.
- [ ] Confirm items with a valid Logo still render the logo image as before.
- [ ] Simulate a failed logo load (e.g. block the URL) and confirm the title text fallback appears.
