### PR TITLE
feat: random trailer start offset for short slideshow dwell

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Plugin.MediaBarEnhanced.Configuration
         /// When true, start trailer/backdrop video playback at a random time within the usable range
         /// instead of always at the beginning (better variety on short slideshow dwell times).
         /// </summary>
-        public bool RandomTrailerStartOffset { get; set; } = false;
+        public bool RandomTrailerStartOffset { get; set; } = true;
         /// <summary>
         /// Minimum start position as percent of usable trailer duration (0-100). Default 10.
         /// </summary>

--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
@@ -28,6 +28,19 @@ namespace Jellyfin.Plugin.MediaBarEnhanced.Configuration
         public string SponsorBlockCategories { get; set; } = "intro,outro,preview";
         public bool PreferLocalTrailers { get; set; } = false;
         public bool RandomizeLocalTrailers { get; set; } = false;
+        /// <summary>
+        /// When true, start trailer/backdrop video playback at a random time within the usable range
+        /// instead of always at the beginning (better variety on short slideshow dwell times).
+        /// </summary>
+        public bool RandomTrailerStartOffset { get; set; } = false;
+        /// <summary>
+        /// Minimum start position as percent of usable trailer duration (0-100). Default 10.
+        /// </summary>
+        public int RandomTrailerStartMinPercent { get; set; } = 10;
+        /// <summary>
+        /// Maximum start position as percent of usable trailer duration (0-100). Default 75.
+        /// </summary>
+        public int RandomTrailerStartMaxPercent { get; set; } = 75;
         public bool PreferLocalBackdrops { get; set; } = false;
         public bool RandomizeThemeVideos { get; set; } = false;
         public bool WaitForTrailerToEnd { get; set; } = true;

--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
@@ -252,6 +252,32 @@
                                         <div class="fieldDescription">Select a random local trailer if multiple exist.
                                         </div>
                                     </div>
+                                    <div class="checkboxContainer checkboxContainer-withDescription"
+                                        id="RandomTrailerStartOffsetContainer">
+                                        <label>
+                                            <input is="emby-checkbox" type="checkbox" id="RandomTrailerStartOffset"
+                                                name="RandomTrailerStartOffset" />
+                                            <span>Random Trailer Start Position</span>
+                                        </label>
+                                        <div class="fieldDescription">Start each backdrop trailer at a random time
+                                            instead of the beginning. Improves variety when slides rotate every few
+                                            seconds through multi-minute trailers.</div>
+                                    </div>
+                                    <div id="RandomTrailerStartRangeContainer"
+                                        style="margin: 0.5em 0 1.5em 2em; display: none;">
+                                        <div class="inputContainer" style="display:inline-block; width:45%; margin-right:4%;">
+                                            <label class="inputLabel inputLabelUnfocused" for="RandomTrailerStartMinPercent">Min start %</label>
+                                            <input is="emby-input" type="number" id="RandomTrailerStartMinPercent"
+                                                name="RandomTrailerStartMinPercent" min="0" max="100" step="1" />
+                                            <div class="fieldDescription">Earliest start within usable trailer (default 10).</div>
+                                        </div>
+                                        <div class="inputContainer" style="display:inline-block; width:45%;">
+                                            <label class="inputLabel inputLabelUnfocused" for="RandomTrailerStartMaxPercent">Max start %</label>
+                                            <input is="emby-input" type="number" id="RandomTrailerStartMaxPercent"
+                                                name="RandomTrailerStartMaxPercent" min="0" max="100" step="1" />
+                                            <div class="fieldDescription">Latest start within usable trailer (default 75).</div>
+                                        </div>
+                                    </div>
                                     <div id="SponsorBlockCategoriesContainer"
                                         style="margin: 0.5em 0 1.5em 2em; display: none;">
                                         <div style="font-weight: bold; margin-bottom: 0.5em; font-size: 0.95em;">
@@ -1160,7 +1186,18 @@
                 toggleSetting('UseSponsorBlock', isTrailerEnabled);
                 toggleSetting('RandomizeThemeVideos', isTrailerEnabled);
                 toggleSetting('RandomizeLocalTrailers', isTrailerEnabled);
+                toggleSetting('RandomTrailerStartOffset', isTrailerEnabled);
+                toggleSetting('RandomTrailerStartMinPercent', isTrailerEnabled);
+                toggleSetting('RandomTrailerStartMaxPercent', isTrailerEnabled);
                 toggleSetting('BackdropVideoDelay', isTrailerEnabled);
+
+                var rts = page.querySelector('#RandomTrailerStartOffset');
+                var rtsRange = page.querySelector('#RandomTrailerStartRangeContainer');
+                if (rts && rtsRange) {
+                    var showRts = rts.checked && isTrailerEnabled;
+                    rtsRange.style.display = showRts ? 'block' : 'none';
+                }
+
 
                 // 3. Custom Media IDs and Seasonal settings are kept editable per user request!
 
@@ -1222,7 +1259,8 @@
                             'EnableCustomMediaIds', 'CustomMediaIds', 'EnableLoadingScreen',
                             'EnableSeasonalContent', 'EnableClientSideSettings', 'SortBy', 'SortOrder',
                             'PreferLocalTrailers', 'OnlyLocalTrailers', 'ApplyLimitsToCustomIds', 'SeasonalSections',
-                            'PreferLocalBackdrops', 'RandomizeThemeVideos', 'RandomizeLocalTrailers',
+                            'PreferLocalBackdrops', 'RandomizeThemeVideos', 'RandomizeLocalTrailers', 'RandomTrailerStartOffset',
+                            'RandomTrailerStartMinPercent', 'RandomTrailerStartMaxPercent',
                             'IncludeWatchedContent', 'ShowPaginationDots', 'ForceSlideCounter', 'MaxParentalRating',
                             'MaxDaysRecent', 'ExcludeSeasonalContent', 'HideArrowsOnMobile',
                             'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
@@ -1576,7 +1614,8 @@
                         'EnableCustomMediaIds', 'CustomMediaIds', 'EnableLoadingScreen',
                         'EnableSeasonalContent', 'EnableClientSideSettings', 'SortBy', 'SortOrder',
                         'PreferLocalTrailers', 'OnlyLocalTrailers', 'ApplyLimitsToCustomIds', 'SeasonalSections',
-                        'PreferLocalBackdrops', 'RandomizeThemeVideos', 'RandomizeLocalTrailers',
+                        'PreferLocalBackdrops', 'RandomizeThemeVideos', 'RandomizeLocalTrailers', 'RandomTrailerStartOffset',
+                        'RandomTrailerStartMinPercent', 'RandomTrailerStartMaxPercent',
                         'IncludeWatchedContent', 'ShowPaginationDots', 'ForceSlideCounter', 'MaxParentalRating',
                         'MaxDaysRecent', 'ExcludeSeasonalContent', 'HideArrowsOnMobile',
                         'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
@@ -1602,6 +1641,8 @@
                         'FadeTransitionDuration': 500,
                         'MaxPaginationDots': 15,
                         'DefaultTrailerVolume': 40,
+                        'RandomTrailerStartMinPercent': 10,
+                        'RandomTrailerStartMaxPercent': 75,
                         'BackdropVideoDelay': 0,
                         'CustomOverlayPositionX': 0,
                         'CustomOverlayPositionY': 0,

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -60,6 +60,9 @@
     sponsorBlockCategories: "intro,outro,preview",
     preferLocalTrailers: false,
     randomizeLocalTrailers: false,
+    randomTrailerStartOffset: false,
+    randomTrailerStartMinPercent: 10,
+    randomTrailerStartMaxPercent: 75,
     preferLocalBackdrops: false,
     randomizeThemeVideos: false,
     includeWatchedContent: false,
@@ -167,6 +170,8 @@
       libraryFilterHint: 'Note: These filters only apply when fetching random or recent items. They do not affect custom playlists or fixed item ID lists.',
       onlyLocalTrailersLabel: 'Only Play Local Trailers',
       onlyLocalTrailersDesc: 'Do not play remote (YouTube) trailers.',
+      randomTrailerStartLabel: 'Random Trailer Start Position',
+      randomTrailerStartDesc: 'Start each backdrop trailer at a random time instead of the beginning.',
       yoYoProgressBarLabel: 'Yo-Yo Progress Bar',
       yoYoProgressBarDesc: 'Empty progress bar from left to right on alternating slides instead of resetting.'
     },
@@ -2714,7 +2719,7 @@
                     if (endTime !== undefined && typeof event.target.loadVideoById === 'function') {
                       event.target.loadVideoById({
                         videoId: videoId,
-                        startSeconds: event.target._startTime || 0,
+                        startSeconds: pickRandomTrailerStartSeconds(event.target._startTime || 0, event.target._endTime, true, itemId),
                         endSeconds: endTime
                       });
                     } else {
@@ -2736,7 +2741,7 @@
                         if (endTime !== undefined && typeof event.target.loadVideoById === 'function') {
                           event.target.loadVideoById({
                             videoId: videoId,
-                            startSeconds: event.target._startTime || 0,
+                            startSeconds: pickRandomTrailerStartSeconds(event.target._startTime || 0, event.target._endTime, true, itemId),
                             endSeconds: endTime
                           });
                         } else {
@@ -3661,11 +3666,8 @@
               videoBackdrop.src = lazySrc;
               videoBackdrop.load(); // Force pre-buffering
             } else {
-              try {
-                if (videoBackdrop.currentTime > 0) {
-                  videoBackdrop.currentTime = 0;
-                }
-              } catch (e) { }
+              // Random or zero start for this slide activation (issue #103)
+              applyHtml5TrailerStartOffset(videoBackdrop, currentItemId, true);
             }
 
             videoBackdrop.muted = STATE.slideshow.isMuted;
@@ -3680,7 +3682,7 @@
                 // Use cueVideoById to buffer video without auto-playing it
                 player.cueVideoById({
                   videoId: player._videoId,
-                  startSeconds: player._startTime || 0,
+                  startSeconds: pickRandomTrailerStartSeconds(player._startTime || 0, player._endTime, true, currentItemId),
                   endSeconds: player._endTime
                 });
 
@@ -3691,7 +3693,7 @@
                   player.setVolume(getEffectiveTrailerVolume());
                 }
               } else if (player && typeof player.seekTo === 'function') {
-                const startTime = player._startTime || 0;
+                const startTime = pickRandomTrailerStartSeconds(player._startTime || 0, player._endTime, true, currentItemId);
                 player.seekTo(startTime);
               }
             }
@@ -3709,6 +3711,7 @@
             }
 
             if (videoBackdrop.tagName === 'VIDEO') {
+              applyHtml5TrailerStartOffset(videoBackdrop, currentItemId, false);
               videoBackdrop.play().catch(e => {
                 // Ignore intentional aborts when sliding away quickly
                 if (e.name === 'AbortError') return;
@@ -3737,7 +3740,7 @@
                 // Zero delay: Natively load and play immediately to preserve Autoplay tokens
                 player.loadVideoById({
                   videoId: player._videoId,
-                  startSeconds: player._startTime || 0,
+                  startSeconds: pickRandomTrailerStartSeconds(player._startTime || 0, player._endTime, true, currentItemId),
                   endSeconds: player._endTime
                 });
 
@@ -5209,6 +5212,7 @@
         { key: 'trailerButton', label: t.trailerButtonLabel, description: t.trailerButtonDesc, default: CONFIG.showTrailerButton },
         { key: 'mobileVideo', label: t.mobileVideoLabel, description: t.mobileVideoDesc, default: CONFIG.enableMobileVideo },
         { key: 'waitForTrailer', label: t.waitForTrailerLabel, description: t.waitForTrailerDesc, default: CONFIG.waitForTrailerToEnd },
+        { key: 'randomTrailerStart', label: t.randomTrailerStartLabel || 'Random Trailer Start Position', description: t.randomTrailerStartDesc || 'Start each backdrop trailer at a random time instead of the beginning.', default: CONFIG.randomTrailerStartOffset },
       ];
 
       let html = `
@@ -5666,6 +5670,116 @@
    * Returns the effective value for waiting for trailer to end, respecting client-side overrides.
    * @returns {boolean} Whether to wait for the trailer to end
    */
+
+  /**
+   * Whether random in-trailer start offset is enabled (client override aware).
+   * @returns {boolean}
+   */
+  function getEffectiveRandomTrailerStart() {
+    return MediaBarEnhancedSettingsManager.getSetting('randomTrailerStart', CONFIG.randomTrailerStartOffset);
+  }
+
+  /**
+   * Clamp a percent-like value into 0..100.
+   * @param {*} v
+   * @param {number} fallback
+   * @returns {number}
+   */
+  function clampTrailerStartPercent(v, fallback) {
+    const n = Number(v);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.max(0, Math.min(100, n));
+  }
+
+  /**
+   * Pick a start time (seconds) within [rangeStart, rangeEnd] for backdrop trailers.
+   * When random start is disabled, returns rangeStart (usually 0 or SponsorBlock start).
+   * Leaves a short residual tail so a brief slide dwell still has motion.
+   *
+   * @param {number} rangeStart
+   * @param {number} rangeEnd
+   * @param {boolean} forceNew - re-roll even if this item already has a cached offset
+   * @param {string} [itemId]
+   * @returns {number}
+   */
+  function pickRandomTrailerStartSeconds(rangeStart, rangeEnd, forceNew, itemId) {
+    const start = Math.max(0, Number(rangeStart) || 0);
+    if (!getEffectiveRandomTrailerStart()) {
+      return start;
+    }
+
+    let end = Number(rangeEnd);
+    if (!Number.isFinite(end) || end <= start + 0.25) {
+      return start;
+    }
+
+    const span = end - start;
+    const minClip = Math.min(5, Math.max(1, span * 0.15));
+    const usableEnd = Math.max(start, end - minClip);
+    const usableSpan = usableEnd - start;
+    if (usableSpan <= 0.5) {
+      return start;
+    }
+
+    let minP = clampTrailerStartPercent(CONFIG.randomTrailerStartMinPercent, 10) / 100;
+    let maxP = clampTrailerStartPercent(CONFIG.randomTrailerStartMaxPercent, 75) / 100;
+    if (minP > maxP) {
+      const tmp = minP;
+      minP = maxP;
+      maxP = tmp;
+    }
+
+    const lo = start + usableSpan * minP;
+    const hi = start + usableSpan * maxP;
+    if (hi <= lo + 0.05) {
+      return lo;
+    }
+
+    if (!STATE.slideshow.trailerStartByItem) {
+      STATE.slideshow.trailerStartByItem = {};
+    }
+
+    if (!forceNew && itemId && STATE.slideshow.trailerStartByItem[itemId] != null) {
+      return STATE.slideshow.trailerStartByItem[itemId];
+    }
+
+    const t = lo + Math.random() * (hi - lo);
+    if (itemId) {
+      STATE.slideshow.trailerStartByItem[itemId] = t;
+    }
+    return t;
+  }
+
+  /**
+   * Apply start offset to an HTML5 video element once duration is known.
+   * @param {HTMLVideoElement} video
+   * @param {string} itemId
+   * @param {boolean} forceNew
+   */
+  function applyHtml5TrailerStartOffset(video, itemId, forceNew) {
+    if (!video || video.tagName !== 'VIDEO') return;
+    const run = () => {
+      try {
+        const duration = video.duration;
+        if (!duration || !Number.isFinite(duration) || duration < 1) return;
+        const t = pickRandomTrailerStartSeconds(0, duration, forceNew, itemId);
+        if (Math.abs((video.currentTime || 0) - t) > 0.4) {
+          video.currentTime = t;
+        }
+      } catch (e) { /* ignore seek races */ }
+    };
+
+    if (video.readyState >= 1 && Number.isFinite(video.duration) && video.duration > 0) {
+      run();
+    } else {
+      const onMeta = () => {
+        video.removeEventListener('loadedmetadata', onMeta);
+        run();
+      };
+      video.addEventListener('loadedmetadata', onMeta);
+    }
+  }
+
   function getEffectiveWaitForTrailer() {
     return MediaBarEnhancedSettingsManager.getSetting('waitForTrailer', CONFIG.waitForTrailerToEnd);
   }

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -60,7 +60,7 @@
     sponsorBlockCategories: "intro,outro,preview",
     preferLocalTrailers: false,
     randomizeLocalTrailers: false,
-    randomTrailerStartOffset: false,
+    randomTrailerStartOffset: true,
     randomTrailerStartMinPercent: 10,
     randomTrailerStartMaxPercent: 75,
     preferLocalBackdrops: false,
@@ -171,7 +171,7 @@
       onlyLocalTrailersLabel: 'Only Play Local Trailers',
       onlyLocalTrailersDesc: 'Do not play remote (YouTube) trailers.',
       randomTrailerStartLabel: 'Random Trailer Start Position',
-      randomTrailerStartDesc: 'Start each backdrop trailer at a random time instead of the beginning.',
+      randomTrailerStartDesc: 'Start each backdrop trailer at a random time instead of the beginning. On by default for the media bar; turn off to always start from the beginning.',
       yoYoProgressBarLabel: 'Yo-Yo Progress Bar',
       yoYoProgressBarDesc: 'Empty progress bar from left to right on alternating slides instead of resetting.'
     },


### PR DESCRIPTION
## Summary

Optional **random in-trailer start** for Media Bar backdrop trailers so short slideshow rotations (~7–15s) show varied mid-trailer moments instead of always the cold open.

**Default: ON** for the media bar (fully configurable — turn off to always start from the beginning).

Closes #103

## Changes

- **`PluginConfiguration`**: `RandomTrailerStartOffset` (bool, default **`true`**), `RandomTrailerStartMinPercent` (10), `RandomTrailerStartMaxPercent` (75)
- **Dashboard `configPage.html`**: checkbox + min/max % fields under Trailers
- **`mediaBarEnhanced.js`**:
  - `pickRandomTrailerStartSeconds` / `applyHtml5TrailerStartOffset` (client key `randomTrailerStart`)
  - HTML5 activate path respects random start
  - YouTube `loadVideoById` / `cueVideoById` / `seekTo` use a start inside SponsorBlock (or full) range
  - Client settings menu toggle under Trailers

## Behavior

| Surface | Default | Configurable |
|---------|---------|--------------|
| **Media Bar** (this PR) | Random start **ON** | Admin + client toggle + min/max % |
| Item detail pages | Start from beginning (separate ElegantFin add-on; random **OFF** there) | — |

- Usable range respects YT `_startTime` / `_endTime` (SponsorBlock)
- Leaves a short residual tail so a brief dwell still has motion
- Per-item offset cached for the slide activation; re-rolled when the slide is entered again with `forceNew`

## Test plan

- [ ] Fresh config: random start **enabled** without touching settings
- [ ] Disable option: trailers start at beginning / SB start
- [ ] Min/max % (e.g. 20–40) constrain the window
- [ ] Local + YouTube + SponsorBlock
- [ ] Client settings toggle overrides server default
- [ ] Autoplay muted still works after seek