### PR TITLE
feat: optional hover audio fade while muted (default off)

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
@@ -32,6 +32,15 @@ namespace Jellyfin.Plugin.MediaBarEnhanced.Configuration
         public bool RandomizeThemeVideos { get; set; } = false;
         public bool WaitForTrailerToEnd { get; set; } = true;
         public bool StartMuted { get; set; } = true;
+        /// <summary>
+        /// When true and playback is muted, hovering the media bar fades sound in;
+        /// leaving fades sound out. Off by default.
+        /// </summary>
+        public bool HoverAudioFade { get; set; } = false;
+        /// <summary>
+        /// Fade duration in milliseconds for hover audio in/out.
+        /// </summary>
+        public int HoverAudioFadeMs { get; set; } = 400;
         public int DefaultTrailerVolume { get; set; } = 40;
         public bool FullWidthVideo { get; set; } = true;
         public bool EnableMobileVideo { get; set; } = false;

--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
@@ -224,6 +224,24 @@
                                         <div class="fieldDescription">Start trailer video playback muted. Autoplay might
                                             fail if unmuted.</div>
                                     </div>
+                                    <div class="checkboxContainer checkboxContainer-withDescription"
+                                        id="HoverAudioFadeContainer">
+                                        <label>
+                                            <input is="emby-checkbox" type="checkbox" id="HoverAudioFade"
+                                                name="HoverAudioFade" />
+                                            <span>Hover Audio Fade</span>
+                                        </label>
+                                        <div class="fieldDescription">While muted, hover the media bar to fade sound in;
+                                            leave to fade out. Off by default. Does not change the mute button state.</div>
+                                    </div>
+                                    <div class="inputContainer" id="HoverAudioFadeMsContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="HoverAudioFadeMs">Hover Audio
+                                            Fade Duration (ms)</label>
+                                        <input is="emby-input" type="number" id="HoverAudioFadeMs"
+                                            name="HoverAudioFadeMs" min="50" max="3000" step="50" />
+                                        <div class="fieldDescription">How long the volume fade takes on hover in/out
+                                            (default 400).</div>
+                                    </div>
 
                                     <div class="checkboxContainer checkboxContainer-withDescription">
                                         <label>
@@ -1156,6 +1174,8 @@
                 toggleSetting('EnableMobileVideo', isTrailerEnabled);
                 toggleSetting('ShowTrailerButton', isTrailerEnabled);
                 toggleSetting('StartMuted', isTrailerEnabled);
+                toggleSetting('HoverAudioFade', isTrailerEnabled);
+                toggleSetting('HoverAudioFadeMs', isTrailerEnabled);
                 toggleSetting('DefaultTrailerVolume', isTrailerEnabled);
                 toggleSetting('UseSponsorBlock', isTrailerEnabled);
                 toggleSetting('RandomizeThemeVideos', isTrailerEnabled);
@@ -1217,7 +1237,7 @@
                             'LoadingCheckInterval', 'MaxPlotLength', 'MaxMovies', 'MaxTvShows',
                             'MaxItems', 'PreloadCount', 'FadeTransitionDuration', 'MaxPaginationDots',
                             'SlideAnimationEnabled', 'EnableVideoBackdrop', 'UseSponsorBlock', 'SponsorBlockCategories',
-                            'WaitForTrailerToEnd', 'StartMuted', 'FullWidthVideo', 'EnableMobileVideo',
+                            'WaitForTrailerToEnd', 'StartMuted', 'HoverAudioFade', 'FullWidthVideo', 'EnableMobileVideo',
                             'ShowTrailerButton', 'AlwaysShowArrows', 'EnableKeyboardControls',
                             'EnableCustomMediaIds', 'CustomMediaIds', 'EnableLoadingScreen',
                             'EnableSeasonalContent', 'EnableClientSideSettings', 'SortBy', 'SortOrder',
@@ -1228,7 +1248,7 @@
                             'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
                             'CustomOverlayStyle', 'CustomOverlayImageStyle', 'CustomOverlayPriority',
                             'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
-                            'BackdropVideoDelay', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume',
+                            'BackdropVideoDelay', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
                             'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
                             'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar'
                         ];
@@ -1571,7 +1591,7 @@
                         'LoadingCheckInterval', 'MaxPlotLength', 'MaxMovies', 'MaxTvShows',
                         'MaxItems', 'PreloadCount', 'FadeTransitionDuration', 'MaxPaginationDots',
                         'SlideAnimationEnabled', 'EnableVideoBackdrop', 'UseSponsorBlock', 'SponsorBlockCategories',
-                        'WaitForTrailerToEnd', 'StartMuted', 'FullWidthVideo', 'EnableMobileVideo',
+                        'WaitForTrailerToEnd', 'StartMuted', 'HoverAudioFade', 'FullWidthVideo', 'EnableMobileVideo',
                         'ShowTrailerButton', 'AlwaysShowArrows', 'EnableKeyboardControls',
                         'EnableCustomMediaIds', 'CustomMediaIds', 'EnableLoadingScreen',
                         'EnableSeasonalContent', 'EnableClientSideSettings', 'SortBy', 'SortOrder',
@@ -1582,7 +1602,7 @@
                         'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
                         'CustomOverlayStyle', 'CustomOverlayImageStyle', 'CustomOverlayPriority',
                         'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
-                        'BackdropVideoDelay', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume',
+                        'BackdropVideoDelay', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
                         'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
                         'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar'
                     ];
@@ -1602,6 +1622,7 @@
                         'FadeTransitionDuration': 500,
                         'MaxPaginationDots': 15,
                         'DefaultTrailerVolume': 40,
+                        'HoverAudioFadeMs': 400,
                         'BackdropVideoDelay': 0,
                         'CustomOverlayPositionX': 0,
                         'CustomOverlayPositionY': 0,

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -65,6 +65,8 @@
     includeWatchedContent: false,
     waitForTrailerToEnd: true,
     startMuted: true,
+    hoverAudioFade: false,
+    hoverAudioFadeMs: 400,
     defaultTrailerVolume: 40,
     fullWidthVideo: true,
     enableMobileVideo: false,
@@ -131,6 +133,8 @@
       mobileModeDesc: 'Height of the media bar on portrait mobile devices.',
       defaultTrailerVolumeLabel: 'Default Trailer Volume',
       defaultTrailerVolumeDesc: 'Set default volume for trailer playback (in %).',
+      hoverAudioFadeLabel: 'Hover Audio Fade',
+      hoverAudioFadeDesc: 'While muted, hover the media bar to fade sound in; leave to fade out. Off by default.',
       clientMenuLocationLabel: 'Settings Button Location',
       clientMenuLocationDesc: 'Choose where the settings button is displayed (Navbar, Sidebar, or Both).',
       clientMenuLocationMobileLabel: 'Settings Button Location (Mobile)',
@@ -443,6 +447,8 @@
       videoPlayers: {},
       sponsorBlockInterval: null,
       isMuted: CONFIG.startMuted,
+      hoverAudioEngaged: false,
+      volumeFadeToken: 0,
       customTrailerUrls: {},
       ytPromise: null,
       autoplayTimeouts: [],
@@ -4091,6 +4097,9 @@
     toggleMute() {
       STATE.slideshow.isMuted = !STATE.slideshow.isMuted;
       const isUnmuting = !STATE.slideshow.isMuted;
+      // Manual mute control cancels ephemeral hover-audio session
+      STATE.slideshow.hoverAudioEngaged = false;
+      STATE.slideshow.volumeFadeToken++;
       const muteButton = document.querySelector('.mute-button');
 
       const updateIcon = () => {
@@ -4959,8 +4968,9 @@
     };
 
     container.addEventListener("mouseenter", showArrows);
-
     container.addEventListener("mouseleave", hideArrows);
+    container.addEventListener("mouseenter", onMediaBarHoverAudioEnter);
+    container.addEventListener("mouseleave", onMediaBarHoverAudioLeave);
 
     if (CONFIG.alwaysShowArrows) {
       showArrows();
@@ -5209,6 +5219,7 @@
         { key: 'trailerButton', label: t.trailerButtonLabel, description: t.trailerButtonDesc, default: CONFIG.showTrailerButton },
         { key: 'mobileVideo', label: t.mobileVideoLabel, description: t.mobileVideoDesc, default: CONFIG.enableMobileVideo },
         { key: 'waitForTrailer', label: t.waitForTrailerLabel, description: t.waitForTrailerDesc, default: CONFIG.waitForTrailerToEnd },
+        { key: 'hoverAudioFade', label: t.hoverAudioFadeLabel || 'Hover Audio Fade', description: t.hoverAudioFadeDesc || 'While muted, hover the media bar to fade sound in; leave to fade out.', default: CONFIG.hoverAudioFade },
       ];
 
       let html = `
@@ -5658,6 +5669,137 @@
    * Returns the effective trailer volume (0-100), respecting client-side overrides.
    * @returns {number} Volume level 0-100
    */
+
+  /**
+   * Whether hover-to-fade audio is enabled (server + optional client override).
+   * Default false.
+   */
+  function isHoverAudioFadeEnabled() {
+    const v = MediaBarEnhancedSettingsManager.getSetting('hoverAudioFade', CONFIG.hoverAudioFade);
+    return v === true || v === 'true' || v === 1 || v === '1';
+  }
+
+  function getHoverAudioFadeMs() {
+    const n = parseInt(
+      MediaBarEnhancedSettingsManager.getSetting('hoverAudioFadeMs', CONFIG.hoverAudioFadeMs),
+      10
+    );
+    if (isNaN(n)) return 400;
+    return Math.max(50, Math.min(3000, n));
+  }
+
+  /**
+   * Get current slide HTML5 video and/or YouTube player, if any.
+   */
+  function getCurrentTrailerPlayback() {
+    const currentItemId = STATE.slideshow.itemIds[STATE.slideshow.currentSlideIndex];
+    if (!currentItemId) return { itemId: null, video: null, yt: null };
+    const currentSlide = document.querySelector(`.slide[data-item-id="${currentItemId}"]`);
+    const video = currentSlide ? currentSlide.querySelector('video') : null;
+    const yt =
+      STATE.slideshow.videoPlayers && STATE.slideshow.videoPlayers[currentItemId]
+        ? STATE.slideshow.videoPlayers[currentItemId]
+        : null;
+    return { itemId: currentItemId, video, yt };
+  }
+
+  /**
+   * Animate trailer volume to target (0-1 for HTML5, 0-100 for YT).
+   * When fading in from muted default, temporarily unmutes without flipping
+   * the mute button / isMuted state unless permanently unmuted.
+   */
+  function fadeTrailerVolume(toAudible, onDone) {
+    const duration = getHoverAudioFadeMs();
+    const token = ++STATE.slideshow.volumeFadeToken;
+    const targetPct = toAudible ? getEffectiveTrailerVolume() : 0;
+    const { video, yt } = getCurrentTrailerPlayback();
+
+    const startHtml5 = video ? (video.muted ? 0 : (typeof video.volume === 'number' ? video.volume : 0)) : 0;
+    const endHtml5 = targetPct / 100;
+    let startYt = 0;
+    try {
+      if (yt && typeof yt.getVolume === 'function') startYt = yt.getVolume();
+    } catch (e) { startYt = toAudible ? 0 : targetPct; }
+    const endYt = targetPct;
+
+    if (toAudible) {
+      STATE.slideshow.hoverAudioEngaged = true;
+      if (video) {
+        try {
+          video.muted = false;
+          video.volume = startHtml5;
+          video.play().catch(() => {});
+        } catch (e) {}
+      }
+      if (yt && typeof yt.unMute === 'function') {
+        try {
+          yt.unMute();
+          if (typeof yt.setVolume === 'function') yt.setVolume(startYt);
+          if (typeof yt.playVideo === 'function') yt.playVideo();
+        } catch (e) {}
+      }
+    }
+
+    const t0 = performance.now();
+    const step = (now) => {
+      if (token !== STATE.slideshow.volumeFadeToken) return;
+      const u = duration <= 0 ? 1 : Math.min(1, (now - t0) / duration);
+      // ease in-out
+      const e = u < 0.5 ? 2 * u * u : 1 - Math.pow(-2 * u + 2, 2) / 2;
+      const vHtml5 = startHtml5 + (endHtml5 - startHtml5) * e;
+      const vYt = startYt + (endYt - startYt) * e;
+      if (video) {
+        try {
+          video.volume = Math.max(0, Math.min(1, vHtml5));
+          if (!toAudible && u >= 1) {
+            video.muted = true;
+            video.volume = 0;
+          }
+        } catch (e) {}
+      }
+      if (yt && typeof yt.setVolume === 'function') {
+        try {
+          yt.setVolume(Math.max(0, Math.min(100, Math.round(vYt))));
+          if (!toAudible && u >= 1 && typeof yt.mute === 'function') {
+            yt.mute();
+          }
+        } catch (e) {}
+      }
+      if (u < 1) {
+        requestAnimationFrame(step);
+      } else {
+        if (!toAudible) {
+          STATE.slideshow.hoverAudioEngaged = false;
+        }
+        if (typeof onDone === 'function') onDone();
+      }
+    };
+    requestAnimationFrame(step);
+  }
+
+  function onMediaBarHoverAudioEnter() {
+    if (!isHoverAudioFadeEnabled()) return;
+    // Only while sound is turned off (muted). If user unmuted via button, leave alone.
+    if (!STATE.slideshow.isMuted) return;
+    if (!STATE.slideshow.isVideoPlaying && !getCurrentTrailerPlayback().video && !getCurrentTrailerPlayback().yt) {
+      // still try — video may exist without flag
+    }
+    fadeTrailerVolume(true);
+  }
+
+  function onMediaBarHoverAudioLeave() {
+    if (!isHoverAudioFadeEnabled()) return;
+    // Only reverse if we engaged hover audio while muted
+    if (!STATE.slideshow.isMuted) return;
+    if (!STATE.slideshow.hoverAudioEngaged && getCurrentTrailerPlayback().video && !getCurrentTrailerPlayback().video.muted) {
+      // engaged path missed flag — still fade out if audible while isMuted
+      fadeTrailerVolume(false);
+      return;
+    }
+    if (!STATE.slideshow.hoverAudioEngaged) return;
+    fadeTrailerVolume(false);
+  }
+
   function getEffectiveTrailerVolume() {
     return parseInt(MediaBarEnhancedSettingsManager.getSetting('defaultTrailerVolume', CONFIG.defaultTrailerVolume), 10);
   }


### PR DESCRIPTION
## Summary

Optional **Hover Audio Fade** for muted trailer playback on the home Media Bar.

- **Off by default** (`HoverAudioFade = false`)
- When enabled **and** the bar is muted: pointer enter → fade volume in; leave → fade out + re-mute
- Does **not** flip the mute button / persistent `isMuted` state
- Manual mute toggle cancels any in-flight hover fade
- Works for **HTML5** local trailers and **YouTube** players
- Configurable fade duration (`HoverAudioFadeMs`, default 400)
- Server admin config + client-side settings toggle

Closes #105

## Config

| Key | Default | Where |
|-----|---------|--------|
| `HoverAudioFade` | `false` | Plugin config + client Trailers tab |
| `HoverAudioFadeMs` | `400` | Plugin config |

## Test plan

- [ ] Fresh install / default config: hover does nothing (still muted)
- [ ] Enable Hover Audio Fade, Start Muted on: hover bar → audio fades in; leave → fades out
- [ ] Click unmute: audio stays on after leave
- [ ] Local trailer (HTML5) + YouTube trailer both respect fade
- [ ] Client setting override works when client-side settings enabled
