### PR TITLE
feat: Add configurable trailer start offset

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
@@ -52,6 +52,7 @@ namespace Jellyfin.Plugin.MediaBarEnhanced.Configuration
         public string SortBy { get; set; } = "Random";
         public string SortOrder { get; set; } = "Ascending";
         public int BackdropVideoDelay { get; set; } = 0;
+        public int TrailerStartOffset { get; set; } = 0;
         public bool ConstrainPlotWidth { get; set; } = false;
         
         public bool EnableCustomOverlay { get; set; } = false;

--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
@@ -343,6 +343,18 @@
                                             visible longer).</div>
                                     </div>
                                 </div>
+
+                                <div class="grid-2">
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="TrailerStartOffset">Trailer
+                                            Start Offset (ms)</label>
+                                        <input is="emby-input" type="number" id="TrailerStartOffset"
+                                            name="TrailerStartOffset" min="0" />
+                                        <div class="fieldDescription">Skip the first part of every trailer, e.g. a
+                                            studio logo. YouTube trailers can only be skipped in whole seconds, and
+                                            SponsorBlock still wins if it skips further. Default is 0 (disabled).</div>
+                                    </div>
+                                </div>
                             </div>
 
                             <!-- Card 3: Layout & Keyboard Controls -->
@@ -1161,6 +1173,7 @@
                 toggleSetting('RandomizeThemeVideos', isTrailerEnabled);
                 toggleSetting('RandomizeLocalTrailers', isTrailerEnabled);
                 toggleSetting('BackdropVideoDelay', isTrailerEnabled);
+                toggleSetting('TrailerStartOffset', isTrailerEnabled);
 
                 // 3. Custom Media IDs and Seasonal settings are kept editable per user request!
 
@@ -1228,7 +1241,7 @@
                             'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
                             'CustomOverlayStyle', 'CustomOverlayImageStyle', 'CustomOverlayPriority',
                             'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
-                            'BackdropVideoDelay', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume',
+                            'BackdropVideoDelay', 'TrailerStartOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume',
                             'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
                             'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar'
                         ];
@@ -1582,7 +1595,7 @@
                         'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
                         'CustomOverlayStyle', 'CustomOverlayImageStyle', 'CustomOverlayPriority',
                         'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
-                        'BackdropVideoDelay', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume',
+                        'BackdropVideoDelay', 'TrailerStartOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume',
                         'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
                         'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar'
                     ];
@@ -1603,6 +1616,7 @@
                         'MaxPaginationDots': 15,
                         'DefaultTrailerVolume': 40,
                         'BackdropVideoDelay': 0,
+                        'TrailerStartOffset': 0,
                         'CustomOverlayPositionX': 0,
                         'CustomOverlayPositionY': 0,
                         'CustomOverlayScale': 100

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -82,6 +82,7 @@
     customOverlayPositionY: 0,
     customOverlayScale: 100,
     backdropVideoDelay: 0,
+    trailerStartOffset: 0,
     constrainPlotWidth: false,
     enableCustomMediaIds: true,
     enableSeasonalContent: false,
@@ -2656,6 +2657,13 @@
               playerVars.start = Math.ceil(segments.startTime);
               console.info("🎬 Media Bar:", `SponsorBlock start skip calculated for video ${videoId}: starting at ${playerVars.start}s`);
             }
+
+            // Skip the configured intro offset, unless SponsorBlock already skips further
+            const startOffset = getTrailerStartOffsetSeconds();
+            if (startOffset > 0 && Math.ceil(startOffset) > (playerVars.start || 0)) {
+              playerVars.start = Math.ceil(startOffset);
+              console.info("🎬 Media Bar:", `Trailer start offset applied for video ${videoId}: starting at ${playerVars.start}s`);
+            }
             if (segments.endTime) {
               playerVars.end = Math.floor(segments.endTime);
               console.info("🎬 Media Bar:", `SponsorBlock end skip calculated for video ${videoId}: ending at ${playerVars.end}s`);
@@ -2847,16 +2855,18 @@
 
           STATE.slideshow.videoPlayers[itemId] = videoBackdrop;
 
+          // Seek to the configured start offset as soon as the duration is known,
+          // including after the src is re-attached when revisiting a slide
+          videoBackdrop.addEventListener('loadedmetadata', (event) => {
+            resetLocalVideoToStart(event.target);
+          });
+
           videoBackdrop.addEventListener('play', (event) => {
             const slide = document.querySelector(`.slide[data-item-id="${itemId}"]`);
             if (!slide || !slide.classList.contains('active')) {
               console.log("🎬 Media Bar:", `Local video ${itemId} started playing but slide is not active, pausing.`);
               event.target.pause();
-              try {
-                if (event.target.currentTime > 0) {
-                  event.target.currentTime = 0;
-                }
-              } catch (e) { }
+              resetLocalVideoToStart(event.target);
               return;
             }
 
@@ -3661,11 +3671,7 @@
               videoBackdrop.src = lazySrc;
               videoBackdrop.load(); // Force pre-buffering
             } else {
-              try {
-                if (videoBackdrop.currentTime > 0) {
-                  videoBackdrop.currentTime = 0;
-                }
-              } catch (e) { }
+              resetLocalVideoToStart(videoBackdrop);
             }
 
             videoBackdrop.muted = STATE.slideshow.isMuted;
@@ -5660,6 +5666,31 @@
    */
   function getEffectiveTrailerVolume() {
     return parseInt(MediaBarEnhancedSettingsManager.getSetting('defaultTrailerVolume', CONFIG.defaultTrailerVolume), 10);
+  }
+
+  /**
+   * Returns how much of the beginning of a trailer should be skipped.
+   * @returns {number} Offset in seconds, 0 when the feature is disabled
+   */
+  function getTrailerStartOffsetSeconds() {
+    const offsetMs = parseInt(CONFIG.trailerStartOffset, 10);
+    return offsetMs > 0 ? offsetMs / 1000 : 0;
+  }
+
+  /**
+   * Rewinds a local trailer video to its configured start offset.
+   * Falls back to the very beginning when the offset would land past the end
+   * of the video, which would otherwise finish playback instantly.
+   * @param {HTMLVideoElement} video The local trailer video element
+   */
+  function resetLocalVideoToStart(video) {
+    const offset = getTrailerStartOffsetSeconds();
+    const target = (video.duration && offset >= video.duration) ? 0 : offset;
+    try {
+      if (video.currentTime !== target) {
+        video.currentTime = target;
+      }
+    } catch (e) { }
   }
 
   /**

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Alternatively, check the URL: `.../web/#/details?id=YOUR_ITEM_ID_IS_HERE&...`
 #### Time Settings
 *   **Shuffle Interval (ms)**: Time each slide is displayed before transitioning to the next (only active on trailer slides if "Wait For Trailer To End" is disabled).
 *   **Backdrop Video Delay (ms)**: Time to wait before playing background videos (leaves static backdrop visible longer).
+*   **Trailer Start Offset (ms)**: Skip the first part of every trailer, e.g. a studio logo. YouTube trailers can only be skipped in whole seconds, and SponsorBlock still wins if it skips further. Default is `0` (disabled).
 
 #### Content Sorting
 Customize the order of slides in the Media Bar.


### PR DESCRIPTION
### What

Adds a **Trailer Start Offset (ms)** setting (Trailers & Backdrops card) that skips the beginning of every trailer backdrop. Default is `0`, so existing installs behave exactly as before.

### Why

Many trailers open with several seconds of studio logos or a black lead-in before anything interesting happens. With short shuffle intervals that is often all you get to see. SponsorBlock covers this for some YouTube trailers, but not for local trailers and not when no segment has been submitted.

### How

- `TrailerStartOffset` added to `PluginConfiguration` and to the config page (enabled/disabled together with the other trailer settings).
- **YouTube**: applied via the player `start` parameter. That parameter is whole seconds only, so the offset is rounded up. If SponsorBlock already calculated a longer skip, SponsorBlock wins.
- **Local trailers**: the video is seeked on `loadedmetadata`, which also covers the re-attach path when a slide is revisited, and the existing rewind-on-slide-change now rewinds to the offset instead of `0`. If the offset would land past the end of the video it falls back to `0` so playback does not end instantly.

### Testing

- `dotnet build -c Release` clean, no warnings.
- Verified on Jellyfin 10.11.11 with **local trailers** at an offset of `3000` ms, including revisiting slides. Default `0` behaves as before.
- The **YouTube** path has not been verified on a live instance yet.