### PR TITLE
Release v3.5.1.0: Child Season Local Trailer Fallback for Series

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Jellyfin.Plugin.MediaBarEnhanced.csproj
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Jellyfin.Plugin.MediaBarEnhanced.csproj
@@ -11,7 +11,7 @@
     <!-- <TreatWarningsAsErrors>false</TreatWarningsAsErrors> -->
     <Title>Jellyfin Media Bar Enhanced Plugin</Title>
     <Authors>CodeDevMLH</Authors>
-    <Version>3.5.0.0</Version>
+    <Version>3.5.1.0</Version>
     <RepositoryUrl>https://github.com/CodeDevMLH/jellyfin-plugin-media-bar-enhanced</RepositoryUrl>
   </PropertyGroup>
 

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -30,7 +30,7 @@
   window.mediaBarEnhancedLoaded = true;
 
   // MARK: Version
-  const PLUGIN_VERSION = "3.4.0.0";
+  const PLUGIN_VERSION = "3.5.1.0";
 
   //Core Module Configuration
   const CONFIG = {
@@ -2532,11 +2532,42 @@
         }
         // 3. For Series or Movie: check primary item ID directly
         else {
-          const response = await fetch(
+          let response = await fetch(
             `${STATE.jellyfinData.serverAddress}/Users/${STATE.jellyfinData.userId}/Items/${itemId}/LocalTrailers`,
             { headers: this.getAuthHeaders() }
           );
           trailers = response.ok ? await response.json() : null;
+
+          // If Series has no direct local trailer, check child Seasons of the Series (Season 1, Season 2, etc.)
+          if ((!trailers || trailers.length === 0) && itemType === 'Series') {
+            try {
+              const seasonsResp = await fetch(
+                `${STATE.jellyfinData.serverAddress}/Shows/${itemId}/Seasons?userId=${STATE.jellyfinData.userId}`,
+                { headers: this.getAuthHeaders() }
+              );
+              if (seasonsResp.ok) {
+                const seasonsData = await seasonsResp.json();
+                const seasons = (seasonsData.Items || []).sort((a, b) => (a.IndexNumber ?? 0) - (b.IndexNumber ?? 0));
+                for (const season of seasons) {
+                  const seasonTrailersResp = await fetch(
+                    `${STATE.jellyfinData.serverAddress}/Users/${STATE.jellyfinData.userId}/Items/${season.Id}/LocalTrailers`,
+                    { headers: this.getAuthHeaders() }
+                  );
+                  if (seasonTrailersResp.ok) {
+                    const seasonTrailers = await seasonTrailersResp.json();
+                    if (seasonTrailers && seasonTrailers.length > 0) {
+                      trailers = trailers ? trailers.concat(seasonTrailers) : seasonTrailers;
+                      if (!CONFIG.randomizeLocalTrailers) {
+                        break; // Stop after finding the first available season's trailer (e.g. Season 1)
+                      }
+                    }
+                  }
+                }
+              }
+            } catch (e) {
+              console.warn("🎬 Media Bar:", `Could not fetch season trailers fallback for series ${itemId}:`, e);
+            }
+          }
 
           if ((!trailers || trailers.length === 0) && (seasonId || seriesId)) {
             const fallbackId = seasonId || seriesId;

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
     "imageUrl": "https://raw.githubusercontent.com/CodeDevMLH/jellyfin-plugin-media-bar-enhanced/refs/heads/main/logo.png",
     "versions": [
       {
+        "version": "3.5.1.0",
+        "changelog": "- feat: Add child Season local trailer fallback for Series items without direct series-level trailers",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/CodeDevMLH/jellyfin-plugin-media-bar-enhanced/releases/download/v3.5.0.0/Jellyfin.Plugin.MediaBarEnhanced.zip",
+        "checksum": "afc70a3536cba6c8e94babe45840205b",
+        "timestamp": "2026-08-12T23:57:40Z"
+      },
+      {
         "version": "3.5.0.0",
         "changelog": "- feat: Add TV Series Season and Episode local trailer support\n- feat: Inherit parent Series Logo, Genres, Ratings, and formatted Title for Season and Episode slides\n- feat: Smart remote trailer ranking to prioritize Official/Main trailers over teasers and alternate cuts (from upstream)\n- feat: Unify YouTube URL parsing across all video endpoints\n- fix: Enhance SponsorBlock API with retries, 3.5s timeout controller, 404 caching, and early pre-fetching\n- fix: Match 'Ends at' time display to the viewer's native device system clock format (12h/24h) (from upstream)",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Release v3.5.1.0

### 🚀 New Features & Enhancements
- **Child Season Trailer Fallback for Series**: Enhanced `ApiUtils.fetchLocalTrailer` so that Series items without direct local trailers automatically scan child Seasons (Season 1, Season 2, etc.) for available local trailers #112 

### 🛠️ Bug Fixes & Refinements
- **Series Local Trailer Discovery**: Fixed issue where Series slides would fall back to remote trailers despite having valid local trailers stored inside individual Season folders.
