### PR TITLE
Add per-library controls for automatic trailer backdrops

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
@@ -81,6 +81,7 @@ namespace Jellyfin.Plugin.MediaBarEnhanced.Configuration
         public string ProgressBarLocation { get; set; } = "Dots";
         public string CustomPlaylists { get; set; } = "[]";
         public string ExcludedLibraries { get; set; } = "";
+        public string TrailerEnabledLibraries { get; set; } = "";
         public bool OnlyLocalTrailers { get; set; } = false;
         public bool YoYoProgressBar { get; set; } = true;
         public bool SyncPageBackdrop { get; set; } = false;

--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
@@ -1093,6 +1093,18 @@
                                     </div>
                                 </div>
                                 <input type="hidden" id="ExcludedLibraries" name="ExcludedLibraries" />
+
+                                <div class="inputContainer" style="margin-top: 1.5em; width: 100%;">
+                                    <label class="inputLabel">Libraries allowed to play trailer backdrops</label>
+                                    <div class="fieldDescription">
+                                        Only checked libraries may autoplay trailer/video backdrops. Unchecked libraries will still appear in Media Bar with static backdrops.
+                                    </div>
+                                    <div id="admin-trailer-libraries-list"
+                                        style="display: flex; flex-direction: column; gap: 0.5em; border: 1px solid #3f3f3f; border-radius: 4px; padding: 0.8em; margin-top: 0.5em;">
+                                        <div class="fieldDescription">Loading libraries...</div>
+                                    </div>
+                                </div>
+                                <input type="hidden" id="TrailerEnabledLibraries" name="TrailerEnabledLibraries" />
                                 <div class="checkboxContainer checkboxContainer-withDescription"
                                     style="margin-top: 1.5em;">
                                     <label>
@@ -1322,7 +1334,7 @@
                             'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
                             'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
                             'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
-                            'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
+                            'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
                         ];
 
                         // Manual mapping for MediaBarIsEnabled -> IsEnabled, to avoid conflicts with other plugins
@@ -1391,6 +1403,47 @@
                                 }
                             }).catch(function (err) {
                                 console.error('Error fetching libraries in admin panel:', err);
+                                listContainer.innerHTML = '<div class="fieldDescription" style="color: #ff3b30;">Failed to load libraries.</div>';
+                            });
+                        })();
+
+                        // Load and render trailer-enabled library checkboxes
+                        (function () {
+                            var listContainer = page.querySelector('#admin-trailer-libraries-list');
+                            var hiddenInput = page.querySelector('#TrailerEnabledLibraries');
+                            if (!listContainer || !hiddenInput) return;
+
+                            var enabledStr = hiddenInput.value || '';
+                            var enabledIds = enabledStr.split(',').filter(function (id) { return id; });
+
+                            var viewsUrl = ApiClient.serverAddress() + '/Items?IncludeItemTypes=CollectionFolder&userId=' + ApiClient.getCurrentUserId();
+                            fetch(viewsUrl, {
+                                headers: {
+                                    'Authorization': 'MediaBrowser Client="' + ApiClient.appName() + '", Device="' + ApiClient.deviceName() + '", DeviceId="' + ApiClient.deviceId() + '", Version="' + ApiClient.appVersion() + '", Token="' + ApiClient.accessToken() + '"'
+                                }
+                            }).then(function (response) {
+                                return response.json();
+                            }).then(function (data) {
+                                var views = data.Items || [];
+                                var html = '';
+
+                                views.forEach(function (view) {
+                                    var isChecked = enabledIds.indexOf(view.Id) !== -1;
+                                    html += '<div class="checkboxContainer checkboxContainer-withDescription" style="margin: 0.3em 0;">' +
+                                        '<label>' +
+                                        '<input is="emby-checkbox" type="checkbox" class="admin-trailer-library-checkbox" data-id="' + view.Id + '" ' + (isChecked ? 'checked' : '') + ' />' +
+                                        '<span>' + view.Name + '</span>' +
+                                        '</label>' +
+                                        '</div>';
+                                });
+
+                                if (html === '') {
+                                    listContainer.innerHTML = '<div class="fieldDescription">No libraries found.</div>';
+                                } else {
+                                    listContainer.innerHTML = html;
+                                }
+                            }).catch(function (err) {
+                                console.error('Error fetching trailer libraries in admin panel:', err);
                                 listContainer.innerHTML = '<div class="fieldDescription" style="color: #ff3b30;">Failed to load libraries.</div>';
                             });
                         })();
@@ -1623,6 +1676,17 @@
                     var excludedInput = page.querySelector('#ExcludedLibraries');
                     if (excludedInput) excludedInput.value = uncheckedIds.join(',');
 
+                    // Trailer-enabled Libraries: checked checkboxes are allowed to autoplay trailer backdrops
+                    var trailerCheckboxes = page.querySelectorAll('.admin-trailer-library-checkbox');
+                    var enabledTrailerLibraryIds = [];
+                    trailerCheckboxes.forEach(function (cb) {
+                        if (cb.checked) {
+                            enabledTrailerLibraryIds.push(cb.getAttribute('data-id'));
+                        }
+                    });
+                    var trailerEnabledInput = page.querySelector('#TrailerEnabledLibraries');
+                    if (trailerEnabledInput) trailerEnabledInput.value = enabledTrailerLibraryIds.join(',');
+
                     // Sync hidden input from SponsorBlock checkboxes
                     (function () {
                         var checkedCats = [];
@@ -1664,7 +1728,7 @@
                         'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
                         'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
                         'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
-                        'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
+                        'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
                     ];
 
                     var numberDefaults = {

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -111,6 +111,7 @@
     customPlaylists: "[]",
     forceSlideCounter: false,
     excludedLibraries: "",
+    trailerEnabledLibraries: "",
     onlyLocalTrailers: false,
     yoYoProgressBar: true,
     syncPageBackdrop: false,
@@ -1705,6 +1706,41 @@
       }
     },
 
+    async resolveItemLibraryId(item) {
+      if (!item || !item.Id) return null;
+
+      if (item.MediaBarLibraryId) return item.MediaBarLibraryId;
+
+      try {
+        const libraryMap = await this.fetchLibraryIds() || {};
+        const libraryIds = [...new Set(Object.values(libraryMap))];
+
+        if (item.ParentId && libraryIds.includes(item.ParentId)) {
+          item.MediaBarLibraryId = item.ParentId;
+          return item.MediaBarLibraryId;
+        }
+
+        const ancestorsUrl = `${STATE.jellyfinData.serverAddress}/Items/${item.Id}/Ancestors`;
+        const response = await fetch(ancestorsUrl, { headers: this.getAuthHeaders() });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ancestors: ${response.statusText}`);
+        }
+
+        const ancestors = await response.json();
+        const libraryAncestor = (ancestors || []).find(ancestor => libraryIds.includes(ancestor.Id));
+
+        if (libraryAncestor) {
+          item.MediaBarLibraryId = libraryAncestor.Id;
+          return item.MediaBarLibraryId;
+        }
+
+        console.warn(`🎬 Media Bar: Could not resolve top-level library for ${item.Id}`);
+        return null;
+      } catch (e) {
+        console.warn(`🎬 Media Bar: Error resolving library for ${item.Id}:`, e);
+        return null;
+      }
+    },
     async applyLibraryFilters(items) {
       if (!items || items.length === 0) return items;
 
@@ -3162,7 +3198,15 @@
       const enableVideo = MediaBarEnhancedSettingsManager.getSetting('videoBackdrops', CONFIG.enableVideoBackdrop);
       const enableMobileVideo = MediaBarEnhancedSettingsManager.getSetting('mobileVideo', CONFIG.enableMobileVideo);
 
-      const shouldPlayVideo = enableVideo && (!isMobile || enableMobileVideo);
+      const trailerEnabledLibraryIds = (CONFIG.trailerEnabledLibraries || '')
+        .split(',')
+        .map(id => id.trim())
+        .filter(id => id);
+
+      const libraryAllowsTrailer = !!item.MediaBarLibraryId &&
+        trailerEnabledLibraryIds.includes(item.MediaBarLibraryId);
+
+      const shouldPlayVideo = enableVideo && libraryAllowsTrailer && (!isMobile || enableMobileVideo);
 
       if (trailerUrl && shouldPlayVideo) {
         STATE.slideshow.hasTrailer = STATE.slideshow.hasTrailer || {};
@@ -3958,6 +4002,8 @@
           return null;
         }
 
+        // Resolve the item's top-level Jellyfin library for per-library trailer rules
+        item.MediaBarLibraryId = await ApiUtils.resolveItemLibraryId(item);
         // Pre-fetch local trailer URL if needed
         const onlyLocal = MediaBarEnhancedSettingsManager.getSetting('onlyLocalTrailers', CONFIG.onlyLocalTrailers);
         const canHaveLocalTrailer = (item.LocalTrailerCount && item.LocalTrailerCount > 0) ||


### PR DESCRIPTION
PR body

What this adds

This PR adds a per-library whitelist for automatic trailer/video backdrops.

Libraries can still be included in Media Bar independently of whether their items are allowed to autoplay trailer backdrops. This makes it possible to keep one library static while retaining trailer backdrops for another.

UI

Adds a new admin section:

Libraries allowed to play trailer backdrops

Checked libraries may autoplay trailer/video backdrops. Unchecked libraries continue to appear in Media Bar with static backdrops.

Configuration

Adds TrailerEnabledLibraries, stored as a comma-separated list of Jellyfin library IDs.

An empty value intentionally means no libraries are allowed to autoplay trailers.

Runtime

The item's top-level library ID is resolved and cached. Automatic video backdrop creation now additionally requires the item's library ID to be present in TrailerEnabledLibraries.

This does not intentionally alter manual trailer-button behavior.

Tested

Built successfully against Jellyfin 10.11 / .NET 9.

Loaded successfully on Jellyfin 10.11.11.

Admin library checkboxes render.

Selection persists to plugin XML.

Verified Movies library selected while Anime remains unselected.

Possible follow-up optimization

Trailer/local-theme/SponsorBlock prefetch currently occurs before the final playback gate. This could be optimized later so disallowed libraries skip trailer-related prefetching entirely.