### PR TITLE
fixed max items for multiple libs

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -1885,6 +1885,35 @@
               return new Date(item.DateCreated) >= pastDate;
             });
           }
+          
+          // filter to max items and max types
+          let movieCount = 0
+          let showCount = 0
+          let keptItems = []
+          for (const item of items) {
+            if((movieCount+showCount) >= CONFIG.maxItems){
+              break;
+            }
+            if (item.Type === 'Movie') {
+              if (movieCount < CONFIG.maxMovies) {
+                movieCount++;
+                keptItems.push(item);
+              }
+            } else if (item.Type === 'Series' || item.Type === 'Season' || item.Type === 'Episode') {
+              if (showCount < CONFIG.maxTvShows) {
+                showCount++;
+                keptItems.push(item);
+              }
+            } else {
+              keptItems.push(item);
+            }
+          }
+          items = keptItems;
+
+          // reshuffle if there are different max number for movies and TV
+          if ((CONFIG.maxMovies != CONFIG.maxTvShows) && (CONFIG.sortBy === 'Random' || CONFIG.sortBy === 'Original')) {
+            items.sort(() => Math.random() - 0.5);
+          }
 
           // Fallback if no items in date range
           if (items.length === 0 && dateFilter !== '') {


### PR DESCRIPTION
## Fix: "Total Max Items" not enforced as a combined cap when multiple libraries are included

### Bug

In `ApiUtils.fetchItemIdsFromServer` (and the equivalent path in `fetchItemsByGenresAndTags`), when more than one library is included in the Media Bar (i.e. the `includedIds.length > 0 && includedIds.length < allLibraryIds.length` branch is taken), items are fetched **per library in parallel**, and `CONFIG.maxItems` ("Total Max Items") is passed as the `Limit` query param on **each individual library request**:

```js
const fetchPromises = includedIds.map(async (libId) => {
  const resp = await fetchItems(dateFilter, libId); // Limit=${CONFIG.maxItems} applied per call
  ...
});
```

As a result, with `Total Max Items = 4` and two included libraries (e.g. Movies + Shows), the plugin fetches up to 4 raw items from Movies **and** up to 4 raw items from Shows — 8 items total — before any further trimming. The setting is effectively multiplied by the number of included libraries instead of being a global cap.

The subsequent Movie/TV content-limit loop (`CONFIG.maxMovies` / `CONFIG.maxTvShows`) trims each *type's* count individually, but nothing trims the **combined total** back down to `CONFIG.maxItems`. So the final slide count is bounded by `maxMovies + maxTvShows`, not by `Total Max Items`, whenever the multi-library path is taken — inconsistent with the single-library/global-query path, where `Limit=CONFIG.maxItems` correctly caps the combined result in one request.

### Fix

After fetching and filtering the results the items are again filtered by applying CONFIG.maxMovies, CONFIG.maxTvShows and CONFIG.maxItems to the final list. In the case where CONFIG.maxMovies != CONFIG.maxTvShows the filtered lists is also randomized again if the CONFIG.sortBy is Random or Original

### Testing

- Set Total Max Items = 6, Max Movies = 4, Max TV Shows = 2, with two included libraries (Movies, Shows).
- **Before:** slideshow shows 12 items (6 movies + 6shows).
- **After:** slideshow shows at most 6 items total, respecting both the per-type caps and the combined cap.