### PR TITLE
Release v3.6.0.0: Per-library trailer controls, Multi-library item limit fix & Jellyfin v12 optimizations

### DIFF
--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/PluginConfiguration.cs
@@ -81,6 +81,7 @@ namespace Jellyfin.Plugin.MediaBarEnhanced.Configuration
         public string ProgressBarLocation { get; set; } = "Dots";
         public string CustomPlaylists { get; set; } = "[]";
         public string ExcludedLibraries { get; set; } = "";
+        public string TrailerEnabledLibraries { get; set; } = "";
         public bool OnlyLocalTrailers { get; set; } = false;
         public bool YoYoProgressBar { get; set; } = true;
         public bool SyncPageBackdrop { get; set; } = false;

--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
@@ -107,7 +107,8 @@
                                     </div>
                                 </div>
                                 <div class="selectContainer" style="margin-top: 1em;">
-                                    <label class="selectLabel" for="ClientMenuLocation">Client Settings Menu Location</label>
+                                    <label class="selectLabel" for="ClientMenuLocation">Client Settings Menu
+                                        Location</label>
                                     <select is="emby-select" id="ClientMenuLocation" name="ClientMenuLocation"
                                         class="selectLayout emby-select-withcolor emby-select"
                                         style="width: 100%; -webkit-appearance: menulist; appearance: menulist;">
@@ -118,10 +119,12 @@
                                         <option value="Navbar+UserMenu">Navbar + User Menu</option>
                                         <option value="All">All Locations (Everywhere)</option>
                                     </select>
-                                    <div class="fieldDescription">Choose where the client-side settings menu can be accessed.</div>
+                                    <div class="fieldDescription">Choose where the client-side settings menu can be
+                                        accessed.</div>
                                 </div>
                                 <div class="selectContainer" style="margin-top: 1em;">
-                                    <label class="selectLabel" for="ClientMenuLocationMobile">Client Settings Menu Location (Mobile)</label>
+                                    <label class="selectLabel" for="ClientMenuLocationMobile">Client Settings Menu
+                                        Location (Mobile)</label>
                                     <select is="emby-select" id="ClientMenuLocationMobile"
                                         name="ClientMenuLocationMobile"
                                         class="selectLayout emby-select-withcolor emby-select"
@@ -133,7 +136,8 @@
                                         <option value="Navbar+UserMenu">Navbar + User Menu</option>
                                         <option value="All">All Locations (Everywhere)</option>
                                     </select>
-                                    <div class="fieldDescription">Choose where the client-side settings menu can be accessed on mobile devices.</div>
+                                    <div class="fieldDescription">Choose where the client-side settings menu can be
+                                        accessed on mobile devices.</div>
                                 </div>
                             </div>
 
@@ -409,14 +413,17 @@
                                         <input is="emby-input" type="number" id="TrailerStartOffset"
                                             name="TrailerStartOffset" min="0" />
                                         <div class="fieldDescription">Skip the first part of every trailer, e.g. a
-                                            studio logo. YouTube trailers skip in whole seconds; SponsorBlock wins if it skips further. Default is 0 (disabled).</div>
+                                            studio logo. YouTube trailers skip in whole seconds; SponsorBlock wins if it
+                                            skips further. Default is 0 (disabled).</div>
                                     </div>
                                     <div class="inputContainer">
                                         <label class="inputLabel inputLabelUnfocused" for="TrailerEndOffset">Trailer
                                             End Offset (ms)</label>
                                         <input is="emby-input" type="number" id="TrailerEndOffset"
                                             name="TrailerEndOffset" min="0" />
-                                        <div class="fieldDescription">Trim the end of every trailer, e.g. end credits. YouTube trailers trim in whole seconds; SponsorBlock wins if it skips further. Default is 0 (disabled).</div>
+                                        <div class="fieldDescription">Trim the end of every trailer, e.g. end credits.
+                                            YouTube trailers trim in whole seconds; SponsorBlock wins if it skips
+                                            further. Default is 0 (disabled).</div>
                                     </div>
                                 </div>
                             </div>
@@ -500,7 +507,8 @@
                                                 name="SyncPageBackdrop" />
                                             <span>Sync Page Backdrop</span>
                                         </label>
-                                        <div class="fieldDescription">Mirrors the featured slide background image into Jellyfin's page background.</div>
+                                        <div class="fieldDescription">Mirrors the featured slide background image into
+                                            Jellyfin's page background.</div>
                                     </div>
                                 </div>
 
@@ -1095,10 +1103,8 @@
                                 <input type="hidden" id="ExcludedLibraries" name="ExcludedLibraries" />
 
                                 <div class="inputContainer" style="margin-top: 1.5em; width: 100%;">
-                                    <label class="inputLabel">Libraries allowed to play trailer backdrops</label>
-                                    <div class="fieldDescription">
-                                        Only checked libraries may autoplay trailer/video backdrops. Unchecked libraries will still appear in Media Bar with static backdrops.
-                                    </div>
+                                    <label class="inputLabel">Libraries allowed to play trailer backdrops (unchecked
+                                        libraries will use static backdrops)</label>
                                     <div id="admin-trailer-libraries-list"
                                         style="display: flex; flex-direction: column; gap: 0.5em; border: 1px solid #3f3f3f; border-radius: 4px; padding: 0.8em; margin-top: 0.5em;">
                                         <div class="fieldDescription">Loading libraries...</div>
@@ -1332,9 +1338,10 @@
                             'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
                             'CustomOverlayStyle', 'CustomOverlayImageStyle', 'CustomOverlayPriority',
                             'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
-                            'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
-                            'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
-                            'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
+                            'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode',
+                            'DefaultTrailerVolume', 'HoverAudioFadeMs', 'ClientMenuLocation', 'ClientMenuLocationMobile',
+                            'CustomPlaylists', 'TransitionEffect', 'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries',
+                            'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
                         ];
 
                         // Manual mapping for MediaBarIsEnabled -> IsEnabled, to avoid conflicts with other plugins
@@ -1366,6 +1373,34 @@
 
                         })();
 
+                        // Helper to fetch libraries across all Jellyfin versions (including v12)
+                        var fetchServerViews = function () {
+                            var userId = ApiClient.getCurrentUserId();
+                            if (typeof ApiClient.getUserViews === 'function') {
+                                return ApiClient.getUserViews(userId).then(function (data) {
+                                    return (data && data.Items) ? data.Items : [];
+                                });
+                            }
+                            var viewsUrl = ApiClient.getUrl ? ApiClient.getUrl('Users/' + userId + '/Views') : (ApiClient.serverAddress() + '/Users/' + userId + '/Views');
+                            return fetch(viewsUrl, {
+                                headers: {
+                                    'Authorization': 'MediaBrowser Client="' + ApiClient.appName() + '", Device="' + ApiClient.deviceName() + '", DeviceId="' + ApiClient.deviceId() + '", Version="' + ApiClient.appVersion() + '", Token="' + ApiClient.accessToken() + '"'
+                                }
+                            }).then(function (res) {
+                                if (!res.ok) throw new Error('Failed to fetch views');
+                                return res.json();
+                            }).then(function (data) {
+                                return (data && data.Items) ? data.Items : [];
+                            }).catch(function (e) {
+                                var fallbackUrl = ApiClient.serverAddress() + '/Items?IncludeItemTypes=CollectionFolder&userId=' + userId;
+                                return fetch(fallbackUrl, {
+                                    headers: {
+                                        'Authorization': 'MediaBrowser Client="' + ApiClient.appName() + '", Device="' + ApiClient.deviceName() + '", DeviceId="' + ApiClient.deviceId() + '", Version="' + ApiClient.appVersion() + '", Token="' + ApiClient.accessToken() + '"'
+                                    }
+                                }).then(function (r) { return r.json(); }).then(function (d) { return (d && d.Items) ? d.Items : []; });
+                            });
+                        };
+
                         // Load and render admin libraries checkboxes
                         (function () {
                             var listContainer = page.querySelector('#admin-libraries-list');
@@ -1375,15 +1410,7 @@
                             var excludedStr = hiddenInput.value || '';
                             var excludedIds = excludedStr.split(',').filter(function (id) { return id; });
 
-                            var viewsUrl = ApiClient.serverAddress() + '/Items?IncludeItemTypes=CollectionFolder&userId=' + ApiClient.getCurrentUserId();
-                            fetch(viewsUrl, {
-                                headers: {
-                                    'Authorization': 'MediaBrowser Client="' + ApiClient.appName() + '", Device="' + ApiClient.deviceName() + '", DeviceId="' + ApiClient.deviceId() + '", Version="' + ApiClient.appVersion() + '", Token="' + ApiClient.accessToken() + '"'
-                                }
-                            }).then(function (response) {
-                                return response.json();
-                            }).then(function (data) {
-                                var views = data.Items || [];
+                            fetchServerViews().then(function (views) {
                                 var html = '';
 
                                 views.forEach(function (view) {
@@ -1413,23 +1440,16 @@
                             var hiddenInput = page.querySelector('#TrailerEnabledLibraries');
                             if (!listContainer || !hiddenInput) return;
 
-                            var enabledStr = hiddenInput.value || '';
-                            var enabledIds = enabledStr.split(',').filter(function (id) { return id; });
-                            var isConfigured = enabledStr.trim().length > 0;
+                            var enabledStr = (hiddenInput.value || '').trim();
+                            var isConfigured = enabledStr.length > 0;
+                            var isNone = enabledStr.toLowerCase() === 'none';
+                            var enabledIds = enabledStr.split(',').map(function (id) { return id.trim(); }).filter(function (id) { return id; });
 
-                            var viewsUrl = ApiClient.serverAddress() + '/Items?IncludeItemTypes=CollectionFolder&userId=' + ApiClient.getCurrentUserId();
-                            fetch(viewsUrl, {
-                                headers: {
-                                    'Authorization': 'MediaBrowser Client="' + ApiClient.appName() + '", Device="' + ApiClient.deviceName() + '", DeviceId="' + ApiClient.deviceId() + '", Version="' + ApiClient.appVersion() + '", Token="' + ApiClient.accessToken() + '"'
-                                }
-                            }).then(function (response) {
-                                return response.json();
-                            }).then(function (data) {
-                                var views = data.Items || [];
+                            fetchServerViews().then(function (views) {
                                 var html = '';
 
                                 views.forEach(function (view) {
-                                    var isChecked = !isConfigured || enabledIds.indexOf(view.Id) !== -1;
+                                    var isChecked = !isConfigured ? true : (isNone ? false : enabledIds.indexOf(view.Id) !== -1);
                                     html += '<div class="checkboxContainer checkboxContainer-withDescription" style="margin: 0.3em 0;">' +
                                         '<label>' +
                                         '<input is="emby-checkbox" type="checkbox" class="admin-trailer-library-checkbox" data-id="' + view.Id + '" ' + (isChecked ? 'checked' : '') + ' />' +
@@ -1686,7 +1706,13 @@
                         }
                     });
                     var trailerEnabledInput = page.querySelector('#TrailerEnabledLibraries');
-                    if (trailerEnabledInput) trailerEnabledInput.value = enabledTrailerLibraryIds.join(',');
+                    if (trailerEnabledInput) {
+                        if (trailerCheckboxes.length > 0 && enabledTrailerLibraryIds.length === 0) {
+                            trailerEnabledInput.value = "none";
+                        } else {
+                            trailerEnabledInput.value = enabledTrailerLibraryIds.join(',');
+                        }
+                    }
 
                     // Sync hidden input from SponsorBlock checkboxes
                     (function () {
@@ -1727,9 +1753,10 @@
                         'EnableCustomOverlay', 'CustomOverlayText', 'CustomOverlayImageUrl',
                         'CustomOverlayStyle', 'CustomOverlayImageStyle', 'CustomOverlayPriority',
                         'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
-                        'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
-                        'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
-                        'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
+                        'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode',
+                        'DefaultTrailerVolume', 'HoverAudioFadeMs', 'ClientMenuLocation', 'ClientMenuLocationMobile',
+                        'CustomPlaylists', 'TransitionEffect', 'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries',
+                        'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
                     ];
 
                     var numberDefaults = {
@@ -2776,8 +2803,9 @@
                 transition: all 0.2s !important;
             }
 
-            /* Spacing overrides for the admin library list */
-            #MediaBarEnhancedConfigurationPage #admin-libraries-list .checkboxContainer {
+            /* Spacing overrides for library and category checkbox lists */
+            #MediaBarEnhancedConfigurationPage #admin-libraries-list .checkboxContainer,
+            #MediaBarEnhancedConfigurationPage #admin-trailer-libraries-list .checkboxContainer {
                 margin-top: 0.2em !important;
                 margin-bottom: 0.2em !important;
             }

--- a/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Configuration/configPage.html
@@ -1093,6 +1093,18 @@
                                     </div>
                                 </div>
                                 <input type="hidden" id="ExcludedLibraries" name="ExcludedLibraries" />
+
+                                <div class="inputContainer" style="margin-top: 1.5em; width: 100%;">
+                                    <label class="inputLabel">Libraries allowed to play trailer backdrops</label>
+                                    <div class="fieldDescription">
+                                        Only checked libraries may autoplay trailer/video backdrops. Unchecked libraries will still appear in Media Bar with static backdrops.
+                                    </div>
+                                    <div id="admin-trailer-libraries-list"
+                                        style="display: flex; flex-direction: column; gap: 0.5em; border: 1px solid #3f3f3f; border-radius: 4px; padding: 0.8em; margin-top: 0.5em;">
+                                        <div class="fieldDescription">Loading libraries...</div>
+                                    </div>
+                                </div>
+                                <input type="hidden" id="TrailerEnabledLibraries" name="TrailerEnabledLibraries" />
                                 <div class="checkboxContainer checkboxContainer-withDescription"
                                     style="margin-top: 1.5em;">
                                     <label>
@@ -1322,7 +1334,7 @@
                             'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
                             'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
                             'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
-                            'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
+                            'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
                         ];
 
                         // Manual mapping for MediaBarIsEnabled -> IsEnabled, to avoid conflicts with other plugins
@@ -1391,6 +1403,47 @@
                                 }
                             }).catch(function (err) {
                                 console.error('Error fetching libraries in admin panel:', err);
+                                listContainer.innerHTML = '<div class="fieldDescription" style="color: #ff3b30;">Failed to load libraries.</div>';
+                            });
+                        })();
+
+                        // Load and render trailer-enabled library checkboxes
+                        (function () {
+                            var listContainer = page.querySelector('#admin-trailer-libraries-list');
+                            var hiddenInput = page.querySelector('#TrailerEnabledLibraries');
+                            if (!listContainer || !hiddenInput) return;
+
+                            var enabledStr = hiddenInput.value || '';
+                            var enabledIds = enabledStr.split(',').filter(function (id) { return id; });
+
+                            var viewsUrl = ApiClient.serverAddress() + '/Items?IncludeItemTypes=CollectionFolder&userId=' + ApiClient.getCurrentUserId();
+                            fetch(viewsUrl, {
+                                headers: {
+                                    'Authorization': 'MediaBrowser Client="' + ApiClient.appName() + '", Device="' + ApiClient.deviceName() + '", DeviceId="' + ApiClient.deviceId() + '", Version="' + ApiClient.appVersion() + '", Token="' + ApiClient.accessToken() + '"'
+                                }
+                            }).then(function (response) {
+                                return response.json();
+                            }).then(function (data) {
+                                var views = data.Items || [];
+                                var html = '';
+
+                                views.forEach(function (view) {
+                                    var isChecked = enabledIds.indexOf(view.Id) !== -1;
+                                    html += '<div class="checkboxContainer checkboxContainer-withDescription" style="margin: 0.3em 0;">' +
+                                        '<label>' +
+                                        '<input is="emby-checkbox" type="checkbox" class="admin-trailer-library-checkbox" data-id="' + view.Id + '" ' + (isChecked ? 'checked' : '') + ' />' +
+                                        '<span>' + view.Name + '</span>' +
+                                        '</label>' +
+                                        '</div>';
+                                });
+
+                                if (html === '') {
+                                    listContainer.innerHTML = '<div class="fieldDescription">No libraries found.</div>';
+                                } else {
+                                    listContainer.innerHTML = html;
+                                }
+                            }).catch(function (err) {
+                                console.error('Error fetching trailer libraries in admin panel:', err);
                                 listContainer.innerHTML = '<div class="fieldDescription" style="color: #ff3b30;">Failed to load libraries.</div>';
                             });
                         })();
@@ -1623,6 +1676,17 @@
                     var excludedInput = page.querySelector('#ExcludedLibraries');
                     if (excludedInput) excludedInput.value = uncheckedIds.join(',');
 
+                    // Trailer-enabled Libraries: checked checkboxes are allowed to autoplay trailer backdrops
+                    var trailerCheckboxes = page.querySelectorAll('.admin-trailer-library-checkbox');
+                    var enabledTrailerLibraryIds = [];
+                    trailerCheckboxes.forEach(function (cb) {
+                        if (cb.checked) {
+                            enabledTrailerLibraryIds.push(cb.getAttribute('data-id'));
+                        }
+                    });
+                    var trailerEnabledInput = page.querySelector('#TrailerEnabledLibraries');
+                    if (trailerEnabledInput) trailerEnabledInput.value = enabledTrailerLibraryIds.join(',');
+
                     // Sync hidden input from SponsorBlock checkboxes
                     (function () {
                         var checkedCats = [];
@@ -1664,7 +1728,7 @@
                         'CustomOverlayPositionX', 'CustomOverlayPositionY', 'CustomOverlayScale',
                         'BackdropVideoDelay', 'TrailerStartOffset', 'TrailerEndOffset', 'ConstrainPlotWidth', 'MobileCompactMode', 'DefaultTrailerVolume', 'HoverAudioFadeMs',
                         'ClientMenuLocation', 'ClientMenuLocationMobile', 'CustomPlaylists', 'TransitionEffect',
-                        'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
+                        'ShowProgressBar', 'ProgressBarLocation', 'ExcludedLibraries', 'TrailerEnabledLibraries', 'YoYoProgressBar', 'SyncPageBackdrop'
                     ];
 
                     var numberDefaults = {

--- a/Jellyfin.Plugin.MediaBarEnhanced/Jellyfin.Plugin.MediaBarEnhanced.csproj
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Jellyfin.Plugin.MediaBarEnhanced.csproj
@@ -11,7 +11,7 @@
     <!-- <TreatWarningsAsErrors>false</TreatWarningsAsErrors> -->
     <Title>Jellyfin Media Bar Enhanced Plugin</Title>
     <Authors>CodeDevMLH</Authors>
-    <Version>3.5.2.0</Version>
+    <Version>3.6.0.0</Version>
     <RepositoryUrl>https://github.com/CodeDevMLH/jellyfin-plugin-media-bar-enhanced</RepositoryUrl>
   </PropertyGroup>
 

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -1885,6 +1885,35 @@
               return new Date(item.DateCreated) >= pastDate;
             });
           }
+          
+          // filter to max items and max types
+          let movieCount = 0
+          let showCount = 0
+          let keptItems = []
+          for (const item of items) {
+            if((movieCount+showCount) >= CONFIG.maxItems){
+              break;
+            }
+            if (item.Type === 'Movie') {
+              if (movieCount < CONFIG.maxMovies) {
+                movieCount++;
+                keptItems.push(item);
+              }
+            } else if (item.Type === 'Series' || item.Type === 'Season' || item.Type === 'Episode') {
+              if (showCount < CONFIG.maxTvShows) {
+                showCount++;
+                keptItems.push(item);
+              }
+            } else {
+              keptItems.push(item);
+            }
+          }
+          items = keptItems;
+
+          // reshuffle if there are different max number for movies and TV
+          if ((CONFIG.maxMovies != CONFIG.maxTvShows) && (CONFIG.sortBy === 'Random' || CONFIG.sortBy === 'Original')) {
+            items.sort(() => Math.random() - 0.5);
+          }
 
           // Fallback if no items in date range
           if (items.length === 0 && dateFilter !== '') {

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -2025,6 +2025,9 @@
         let keptItems = [];
 
         for (const item of items) {
+          if ((movieCount + showCount) >= CONFIG.maxItems) {
+            break;
+          }
           if (item.Type === 'Movie') {
             if (movieCount < CONFIG.maxMovies) {
               movieCount++;

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -30,7 +30,7 @@
   window.mediaBarEnhancedLoaded = true;
 
   // MARK: Version
-  const PLUGIN_VERSION = "3.5.2.0";
+  const PLUGIN_VERSION = "3.6.0.0";
 
   //Core Module Configuration
   const CONFIG = {
@@ -1935,13 +1935,13 @@
               return new Date(item.DateCreated) >= pastDate;
             });
           }
-          
+
           // filter to max items and max types
           let movieCount = 0
           let showCount = 0
           let keptItems = []
           for (const item of items) {
-            if((movieCount+showCount) >= CONFIG.maxItems){
+            if ((movieCount + showCount) >= CONFIG.maxItems) {
               break;
             }
             if (item.Type === 'Movie') {
@@ -2524,7 +2524,7 @@
           console.warn("🎬 Media Bar:", "Could not extract YouTube Video ID from YouTube URL:", urlToCheck);
         }
         return videoId;
-      } catch (e) {}
+      } catch (e) { }
       return null;
     },
 
@@ -3249,14 +3249,17 @@
 
       const enableMobileVideo = MediaBarEnhancedSettingsManager.getSetting('mobileVideo', CONFIG.enableMobileVideo);
 
-      const trailerEnabledLibraryIds = (CONFIG.trailerEnabledLibraries || '')
+      const rawTrailerLibs = (CONFIG.trailerEnabledLibraries || '').trim();
+      const trailerEnabledLibraryIds = rawTrailerLibs
         .split(',')
         .map(id => id.trim())
         .filter(id => id);
 
-      const libraryAllowsTrailer = !CONFIG.trailerEnabledLibraries ||
-        trailerEnabledLibraryIds.length === 0 ||
-        (!!item.MediaBarLibraryId && trailerEnabledLibraryIds.includes(item.MediaBarLibraryId));
+      const libraryAllowsTrailer = rawTrailerLibs === ''
+        ? true
+        : rawTrailerLibs.toLowerCase() === 'none'
+          ? false
+          : (!!item.MediaBarLibraryId && trailerEnabledLibraryIds.includes(item.MediaBarLibraryId));
 
       const shouldPlayVideo = enableVideo && libraryAllowsTrailer && (!isMobile || enableMobileVideo);
 

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -111,6 +111,7 @@
     customPlaylists: "[]",
     forceSlideCounter: false,
     excludedLibraries: "",
+    trailerEnabledLibraries: "",
     onlyLocalTrailers: false,
     yoYoProgressBar: true,
     syncPageBackdrop: false,
@@ -1705,6 +1706,41 @@
       }
     },
 
+    async resolveItemLibraryId(item) {
+      if (!item || !item.Id) return null;
+
+      if (item.MediaBarLibraryId) return item.MediaBarLibraryId;
+
+      try {
+        const libraryMap = await this.fetchLibraryIds() || {};
+        const libraryIds = [...new Set(Object.values(libraryMap))];
+
+        if (item.ParentId && libraryIds.includes(item.ParentId)) {
+          item.MediaBarLibraryId = item.ParentId;
+          return item.MediaBarLibraryId;
+        }
+
+        const ancestorsUrl = `${STATE.jellyfinData.serverAddress}/Items/${item.Id}/Ancestors`;
+        const response = await fetch(ancestorsUrl, { headers: this.getAuthHeaders() });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ancestors: ${response.statusText}`);
+        }
+
+        const ancestors = await response.json();
+        const libraryAncestor = (ancestors || []).find(ancestor => libraryIds.includes(ancestor.Id));
+
+        if (libraryAncestor) {
+          item.MediaBarLibraryId = libraryAncestor.Id;
+          return item.MediaBarLibraryId;
+        }
+
+        console.warn(`🎬 Media Bar: Could not resolve top-level library for ${item.Id}`);
+        return null;
+      } catch (e) {
+        console.warn(`🎬 Media Bar: Error resolving library for ${item.Id}:`, e);
+        return null;
+      }
+    },
     async applyLibraryFilters(items) {
       if (!items || items.length === 0) return items;
 
@@ -3162,7 +3198,15 @@
       const enableVideo = MediaBarEnhancedSettingsManager.getSetting('videoBackdrops', CONFIG.enableVideoBackdrop);
       const enableMobileVideo = MediaBarEnhancedSettingsManager.getSetting('mobileVideo', CONFIG.enableMobileVideo);
 
-      const shouldPlayVideo = enableVideo && (!isMobile || enableMobileVideo);
+      const trailerEnabledLibraryIds = (CONFIG.trailerEnabledLibraries || '')
+        .split(',')
+        .map(id => id.trim())
+        .filter(id => id);
+
+      const libraryAllowsTrailer = !!item.MediaBarLibraryId &&
+        trailerEnabledLibraryIds.includes(item.MediaBarLibraryId);
+
+      const shouldPlayVideo = enableVideo && libraryAllowsTrailer && (!isMobile || enableMobileVideo);
 
       if (trailerUrl && shouldPlayVideo) {
         STATE.slideshow.hasTrailer = STATE.slideshow.hasTrailer || {};
@@ -3958,6 +4002,8 @@
           return null;
         }
 
+        // Resolve the item's top-level Jellyfin library for per-library trailer rules
+        item.MediaBarLibraryId = await ApiUtils.resolveItemLibraryId(item);
         // Pre-fetch local trailer URL if needed
         const onlyLocal = MediaBarEnhancedSettingsManager.getSetting('onlyLocalTrailers', CONFIG.onlyLocalTrailers);
         const canHaveLocalTrailer = (item.LocalTrailerCount && item.LocalTrailerCount > 0) ||

--- a/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
+++ b/Jellyfin.Plugin.MediaBarEnhanced/Web/mediaBarEnhanced.js
@@ -1,7 +1,7 @@
 /*
  * Jellyfin Slideshow by M0RPH3US v4.0.1
  * Modified by CodeDevMLH
- * 
+ *
  * New features:
  * - optional Trailer background video support (youtube or local trailer/backdrop videos)
  * - option to make video backdrops full width
@@ -796,6 +796,8 @@
     const finishLoading = () => {
       clearInterval(progressInterval);
       clearInterval(checkInterval);
+      window.removeEventListener("hashchange", leavePageHandler);
+      window.removeEventListener("popstate", leavePageHandler);
       progressBar.style.transition = "width 300ms ease-in-out";
       progressBar.style.width = "100%";
       unfilledBar.style.width = "0%";
@@ -812,6 +814,18 @@
         });
       });
     };
+
+    // If the user navigates away from home before loading finishes, tear the
+    // overlay down immediately instead of leaving it running/visible on other pages.
+    const leavePageHandler = () => {
+      const hash = window.location.hash.toLowerCase();
+      const stillHome = hash === "#/home.html" || hash === "#/home" || hash === "";
+      if (!stillHome) {
+        finishLoading();
+      }
+    };
+    window.addEventListener("hashchange", leavePageHandler);
+    window.addEventListener("popstate", leavePageHandler);
 
     // Global Failsafe, force remove loading screen after 15 seconds to prevent infinite lockouts
     setTimeout(() => {
@@ -3111,55 +3125,60 @@
 
       const onlyLocal = MediaBarEnhancedSettingsManager.getSetting('onlyLocalTrailers', CONFIG.onlyLocalTrailers);
 
-      // 1. Check for Remote/Local Trailers
+      // Client Setting Overrides
+      const enableVideo = MediaBarEnhancedSettingsManager.getSetting('videoBackdrops', CONFIG.enableVideoBackdrop);
+      const showTrailerBtnCheck = MediaBarEnhancedSettingsManager.getSetting('trailerButton', CONFIG.showTrailerButton);
+      const needsTrailerUrl = enableVideo || showTrailerBtnCheck;
+
+      // 1. Check for Remote/Local Trailers (skip entirely if neither video backdrops
+      // nor the trailer button are enabled, nothing would ever use trailerUrl)
       // Priority: Custom Config URL > (PreferLocal -> Local) > Metadata RemoteTrailer
+      if (needsTrailerUrl) {
+        // 1a. Custom URL override
+        if (STATE.slideshow.customTrailerUrls && STATE.slideshow.customTrailerUrls[itemId]) {
+          const customValue = STATE.slideshow.customTrailerUrls[itemId];
 
-      // 1a. Custom URL override
-      if (STATE.slideshow.customTrailerUrls && STATE.slideshow.customTrailerUrls[itemId]) {
-        const customValue = STATE.slideshow.customTrailerUrls[itemId];
+          // Check if the custom value is a Jellyfin Item ID (GUID)
+          const guidMatch = customValue.match(/^([0-9a-f]{32})$/i);
 
-        // Check if the custom value is a Jellyfin Item ID (GUID)
-        const guidMatch = customValue.match(/^([0-9a-f]{32})$/i);
+          if (guidMatch) {
+            const videoId = guidMatch[1];
+            console.log("🎬 Media Bar:", `Using custom local video ID for ${itemId}: ${videoId}`);
 
-        if (guidMatch) {
-          const videoId = guidMatch[1];
-          console.log("🎬 Media Bar:", `Using custom local video ID for ${itemId}: ${videoId}`);
-
-          trailerUrl = {
-            id: videoId,
-            url: `${STATE.jellyfinData.serverAddress}/Videos/${videoId}/stream.mp4?api_key=${STATE.jellyfinData.accessToken}&static=true`
-          };
-        } else {
-          // Assume it's a standard URL (YouTube, etc.)
-          trailerUrl = customValue;
-          console.log("🎬 Media Bar:", `Using custom trailer URL for ${itemId}: ${trailerUrl}`);
+            trailerUrl = {
+              id: videoId,
+              url: `${STATE.jellyfinData.serverAddress}/Videos/${videoId}/stream.mp4?api_key=${STATE.jellyfinData.accessToken}&static=true`
+            };
+          } else {
+            // Assume it's a standard URL (YouTube, etc.)
+            trailerUrl = customValue;
+            console.log("🎬 Media Bar:", `Using custom trailer URL for ${itemId}: ${trailerUrl}`);
+          }
         }
-      }
-      // 1b. Check Theme Video if preferred (Local Backdrop)
-      else if (CONFIG.preferLocalBackdrops && item.themeVideoUrl) {
-        trailerUrl = item.themeVideoUrl;
-        console.log("🎬 Media Bar:", `Using theme video (local backdrop) for ${itemId}: ${trailerUrl.url || trailerUrl}`);
-      }
-      // 1c. Check Local Trailer if preferred or restricted to only local
-      else if ((CONFIG.preferLocalTrailers || onlyLocal) && item.localTrailerUrl) {
-        trailerUrl = item.localTrailerUrl;
-        console.log("🎬 Media Bar:", `Using local trailer for ${itemId}: ${trailerUrl.url || trailerUrl}`);
-      }
-      // 1d. Fallback to Remote Trailer (only if not restricted to only local)
-      else if (!onlyLocal && item.RemoteTrailers && item.RemoteTrailers.length > 0) {
-        trailerUrl = ApiUtils.selectBestRemoteTrailer(item.RemoteTrailers);
-        console.log("🎬 Media Bar:", `Using remote trailer for ${itemId}: ${trailerUrl}`);
-      }
-      // 1e. Final Fallback to Local Trailer (even if not preferred)
-      else if (item.localTrailerUrl) {
-        trailerUrl = item.localTrailerUrl;
-        console.log("🎬 Media Bar:", `Using local trailer fallback for ${itemId}: ${trailerUrl.url || trailerUrl}`);
+        // 1b. Check Theme Video if preferred (Local Backdrop)
+        else if (CONFIG.preferLocalBackdrops && item.themeVideoUrl) {
+          trailerUrl = item.themeVideoUrl;
+          console.log("🎬 Media Bar:", `Using theme video (local backdrop) for ${itemId}: ${trailerUrl.url || trailerUrl}`);
+        }
+        // 1c. Check Local Trailer if preferred or restricted to only local
+        else if ((CONFIG.preferLocalTrailers || onlyLocal) && item.localTrailerUrl) {
+          trailerUrl = item.localTrailerUrl;
+          console.log("🎬 Media Bar:", `Using local trailer for ${itemId}: ${trailerUrl.url || trailerUrl}`);
+        }
+        // 1d. Fallback to Remote Trailer (only if not restricted to only local)
+        else if (!onlyLocal && item.RemoteTrailers && item.RemoteTrailers.length > 0) {
+          trailerUrl = ApiUtils.selectBestRemoteTrailer(item.RemoteTrailers);
+          console.log("🎬 Media Bar:", `Using remote trailer for ${itemId}: ${trailerUrl}`);
+        }
+        // 1e. Final Fallback to Local Trailer (even if not preferred)
+        else if (item.localTrailerUrl) {
+          trailerUrl = item.localTrailerUrl;
+          console.log("🎬 Media Bar:", `Using local trailer fallback for ${itemId}: ${trailerUrl.url || trailerUrl}`);
+        }
       }
 
       const isMobile = /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
-      // Client Setting Overrides
-      const enableVideo = MediaBarEnhancedSettingsManager.getSetting('videoBackdrops', CONFIG.enableVideoBackdrop);
       const enableMobileVideo = MediaBarEnhancedSettingsManager.getSetting('mobileVideo', CONFIG.enableMobileVideo);
 
       const shouldPlayVideo = enableVideo && (!isMobile || enableMobileVideo);
@@ -3958,21 +3977,27 @@
           return null;
         }
 
+        // Trailer/theme-video data is only ever consumed for video backdrops or the trailer button popup
+        // skip all of these lookups when both are disabled.
+        const enableVideo = MediaBarEnhancedSettingsManager.getSetting('videoBackdrops', CONFIG.enableVideoBackdrop);
+        const showTrailerBtn = MediaBarEnhancedSettingsManager.getSetting('trailerButton', CONFIG.showTrailerButton);
+        const needsTrailerData = enableVideo || showTrailerBtn;
+
         // Pre-fetch local trailer URL if needed
         const onlyLocal = MediaBarEnhancedSettingsManager.getSetting('onlyLocalTrailers', CONFIG.onlyLocalTrailers);
         const canHaveLocalTrailer = (item.LocalTrailerCount && item.LocalTrailerCount > 0) ||
           item.Type === 'Series' || item.Type === 'Season' || item.Type === 'Episode';
-        if (CONFIG.preferLocalTrailers || onlyLocal || canHaveLocalTrailer) {
+        if (needsTrailerData && (CONFIG.preferLocalTrailers || onlyLocal || canHaveLocalTrailer)) {
           item.localTrailerUrl = await ApiUtils.fetchLocalTrailer(item);
         }
 
         // Pre-fetch theme video URL if needed
-        if (CONFIG.preferLocalBackdrops) {
+        if (needsTrailerData && CONFIG.preferLocalBackdrops) {
           item.themeVideoUrl = await ApiUtils.fetchThemeVideos(itemId);
         }
 
         // Pre-fetch SponsorBlock data early for remote YouTube trailers
-        if (CONFIG.useSponsorBlock && !onlyLocal && item.RemoteTrailers && item.RemoteTrailers.length > 0) {
+        if (needsTrailerData && CONFIG.useSponsorBlock && !onlyLocal && item.RemoteTrailers && item.RemoteTrailers.length > 0) {
           const ytId = ApiUtils.extractYouTubeId(item.RemoteTrailers[0].Url);
           if (ytId) {
             ApiUtils.fetchSponsorBlockData(ytId); // Trigger background pre-fetch into cache
@@ -4091,7 +4116,7 @@
 
       const totalItems = STATE.slideshow.totalItems || 0;
 
-      // dynamically lower the max dots threshold on small screens 
+      // dynamically lower the max dots threshold on small screens
       let effectiveMaxDots = CONFIG.maxPaginationDots;
       if (window.matchMedia("(max-width: 767px) and (orientation: portrait)").matches) {
         const availableWidth = window.innerWidth * 0.9;
@@ -5504,11 +5529,11 @@
      *  - Return Default Custom IDs.
      * If no Custom Media IDs are enabled:
      *  - Return empty result (triggering random fallback).
-     * 
+     *
      * Supports special prefixes in the ID field:
      *  - genre:Action  --> filter by genre
      *  - tag:2000s     --> filter by tag
-     * 
+     *
      * @returns {{ ids: string[], genres: string[], tags: string[] }} Parsed result
      */
     parseIdsString(idsString) {
@@ -5635,7 +5660,7 @@
         }
       }
 
-      // If NOT using seasonal content (disabled or no match), 
+      // If NOT using seasonal content (disabled or no match),
       // Custom IDs are disabled, return empty to skip to random
       if (!usingSeasonal && !CONFIG.enableCustomMediaIds) {
         return { ids: [], genres: [], tags: [] };
@@ -6475,7 +6500,7 @@
         <img src="${STATE.jellyfinData.serverAddress}/MediaBarEnhanced/Resources/assets/logo_SW.svg" draggable="false" class="media-bar-settings-logo" />
         <h3 class="media-bar-settings-title">${t.title}</h3>
     </div>
-    
+
     <div class="media-bar-client-tabs">
         <button type="button" class="media-bar-client-tab active" data-tab="mb-client-tab-general" tabindex="0">
             <svg style="width: 18px; height: 18px; fill: currentColor; flex-shrink: 0;" viewBox="0 0 24 24"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>
@@ -6543,7 +6568,7 @@
         </select>
     </div>
         </div>
-        
+
         <!-- TRAILERS TAB -->
         <div id="mb-client-tab-trailers" class="media-bar-client-tab-content" style="display: none;">
     `;
@@ -6580,7 +6605,7 @@
         </select>
     </div>
         </div>
-        
+
         <!-- LAYOUT TAB -->
         <div id="mb-client-tab-layout" class="media-bar-client-tab-content" style="display: none;">
     `;
@@ -6676,7 +6701,7 @@
         </label>
     </div>
         </div>
-        
+
         <!-- LIBRARIES TAB -->
         <div id="mb-client-tab-libraries" class="media-bar-client-tab-content" style="display: none; flex-direction: column; gap: 0.5rem; max-height: 250px; overflow-y: auto; padding: 0.5rem; width: 100%; box-sizing: border-box;">
             <div class="media-bar-loading-libraries" style="text-align: center; color: var(--text-muted); padding: 1rem;">Loading libraries...</div>

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
     "imageUrl": "https://raw.githubusercontent.com/CodeDevMLH/jellyfin-plugin-media-bar-enhanced/refs/heads/main/logo.png",
     "versions": [
       {
+        "version": "3.6.0.0",
+        "changelog": "- feat: Add per-library trailer backdrop autoplay controls with static backdrop fallback (#117)\n- fix: Enforce global CONFIG.maxItems limit across multi-library queries (#119)\n- fix: Skip trailer lookups when video is disabled and tear down loading screen on route departure (#121)\n- fix: Fix library fetching in admin dashboard for Jellyfin v12 compatibility",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/CodeDevMLH/jellyfin-plugin-media-bar-enhanced/releases/download/v3.5.2.0/Jellyfin.Plugin.MediaBarEnhanced.zip",
+        "checksum": "344e806cbcddde9e41927b9dd9fec8bd",
+        "timestamp": "2026-08-17T00:04:01Z"
+      },
+      {
         "version": "3.5.2.0",
         "changelog": "- feat: Add Sync Page Backdrop option to mirror active slide background in Jellyfin's page background (from upstream with fixes)\n- feat: Add parent series backdrop image fallback for Season and Episode slides\n- fix: Prevent TV mode autofocus from stealing focus when returning from details pages\n- fix: Prevent unintended close events in client settings popup",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Release v3.6.0.0

### 🚀 New Features & Enhancements
- **Per-Library Trailer Backdrops**: Added admin configuration allowing users to select specifically which libraries can autoplay video trailers, with static backdrops used for unselected libraries (#117 by @lawyer-ships-it).
- **Explicit None Trailer Selection**: Added explicit `none` persistence to allow administrators to completely disable video trailers via library checkboxes while keeping full backwards compatibility for unconfigured updates.

### 🛠️ Bug Fixes & Refinements
- **Multi-Library Content Limit**: Fixed an issue where querying multiple libraries multiplied the item limits instead of capping globally to `CONFIG.maxItems` (#119 by @lawyer-ships-it).
- **Navigation Teardown & Request Optimization**: Skip remote trailer and SponsorBlock API requests when video backdrops and trailer buttons are disabled, and immediately tear down the loading screen if navigating away from the home screen (#121 by @lawyer-ships-it).
- **Jellyfin v12 Admin Library Fetching**: Updated admin configuration page library resolution to utilize `fetchServerViews` (`ApiClient.getUserViews` / `/Users/{id}/Views`) for full compatibility with Jellyfin v12.
